### PR TITLE
Add manual save backup management

### DIFF
--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -838,7 +838,7 @@ margin_bottom = 270.0
 [node name="Label" type="Label" parent="Main/Tabs/Backups/Available"]
 margin_right = 769.0
 margin_bottom = 29.0
-text = "Available:"
+text = "Save directory backups:"
 align = 1
 
 [node name="BackupsList" type="ItemList" parent="Main/Tabs/Backups/Available" groups=["disable_during_backup_operations"]]

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -120,11 +120,12 @@ margin_bottom = 91.0
 [node name="Tabs" type="TabContainer" parent="Main" groups=["disable_during_backup_operations", "disable_during_mod_operations", "disable_during_soundpack_operations", "disable_while_fetching_releases", "disable_while_installing_game"]]
 margin_top = 97.0
 margin_right = 784.0
-margin_bottom = 418.0
+margin_bottom = 503.0
 tab_align = 0
 script = ExtResource( 16 )
 
 [node name="Game" type="VBoxContainer" parent="Main/Tabs"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
@@ -538,8 +539,8 @@ window_title = "Open a File"
 mode = 0
 access = 2
 filters = PoolStringArray( "*.zip" )
-current_dir = "/mnt/data/Godot/Catapult/Changelog"
-current_path = "/mnt/data/Godot/Catapult/Changelog/"
+current_dir = "/mnt/data/Godot/Catapult/Project"
+current_path = "/mnt/data/Godot/Catapult/Project/"
 
 [node name="Fonts" type="VBoxContainer" parent="Main/Tabs"]
 visible = false
@@ -822,7 +823,6 @@ margin_right = 769.0
 margin_bottom = 539.0
 
 [node name="Backups" type="VBoxContainer" parent="Main/Tabs"]
-visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
@@ -882,12 +882,12 @@ margin_bottom = 284.0
 [node name="Current" type="VBoxContainer" parent="Main/Tabs/Backups"]
 margin_top = 290.0
 margin_right = 769.0
-margin_bottom = 389.0
+margin_bottom = 360.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Backups/Current"]
 margin_right = 769.0
 margin_bottom = 29.0
-text = "Manual Backup"
+text = "Manual backup"
 align = 1
 
 [node name="HBox" type="HBoxContainer" parent="Main/Tabs/Backups/Current"]
@@ -900,20 +900,24 @@ margin_right = 61.0
 margin_bottom = 29.0
 text = "Name:"
 
-[node name="EditName" type="LineEdit" parent="Main/Tabs/Backups/Current/HBox" groups=["disable_during_backup_operations"]]
+[node name="EditName" type="LineEdit" parent="Main/Tabs/Backups/Current/HBox"]
 margin_left = 67.0
-margin_right = 769.0
+margin_right = 695.0
 margin_bottom = 29.0
 size_flags_horizontal = 3
 placeholder_text = "Enter name for new backup"
 
-[node name="BtnCreate" type="Button" parent="Main/Tabs/Backups/Current" groups=["disable_during_backup_operations"]]
-margin_left = 350.0
-margin_top = 70.0
-margin_right = 418.0
-margin_bottom = 99.0
+[node name="BtnCreate" type="Button" parent="Main/Tabs/Backups/Current/HBox" groups=["disable_during_backup_operations"]]
+margin_left = 701.0
+margin_right = 769.0
+margin_bottom = 29.0
 size_flags_horizontal = 4
 text = "Create"
+
+[node name="Spacer" type="Control" parent="Main/Tabs/Backups/Current"]
+margin_top = 70.0
+margin_right = 769.0
+margin_bottom = 70.0
 
 [node name="Settings" type="VBoxContainer" parent="Main/Tabs"]
 visible = false
@@ -1233,7 +1237,7 @@ size_flags_horizontal = 4
 text = "Test path resolution in PathHelper"
 
 [node name="Log" type="RichTextLabel" parent="Main"]
-margin_top = 424.0
+margin_top = 509.0
 margin_right = 784.0
 margin_bottom = 984.0
 focus_mode = 2
@@ -1362,7 +1366,7 @@ __meta__ = {
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnRefresh" to="Main/Tabs/Backups" method="_on_BtnRefresh_pressed"]
 [connection signal="text_changed" from="Main/Tabs/Backups/Current/HBox/EditName" to="Main/Tabs/Backups" method="_on_EditName_text_changed"]
 [connection signal="text_entered" from="Main/Tabs/Backups/Current/HBox/EditName" to="Main/Tabs/Backups" method="_on_EditName_text_entered"]
-[connection signal="pressed" from="Main/Tabs/Backups/Current/BtnCreate" to="Main/Tabs/Backups" method="_on_BtnCreate_pressed"]
+[connection signal="pressed" from="Main/Tabs/Backups/Current/HBox/BtnCreate" to="Main/Tabs/Backups" method="_on_BtnCreate_pressed"]
 [connection signal="toggled" from="Main/Tabs/Settings/ShowGameDesc" to="Main/Tabs/Settings" method="_on_ShowGameDesc_toggled"]
 [connection signal="toggled" from="Main/Tabs/Settings/PrintTips" to="Main/Tabs/Settings" method="_on_PrintTips_toggled"]
 [connection signal="toggled" from="Main/Tabs/Settings/UpdateToSame" to="Main/Tabs/Settings" method="_on_UpdateToSame_toggled"]

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -1356,6 +1356,7 @@ __meta__ = {
 [connection signal="toggled" from="Main/Tabs/Fonts/FontSelection/LeftPane/PreviewCyrillic" to="Main/Tabs/Fonts" method="_on_PreviewCyrillic_toggled"]
 [connection signal="pressed" from="Main/Tabs/Fonts/FontSelection/LeftPane/OtherSettings/HelpIcon" to="Main/Tabs/Fonts" method="_on_HelpIcon_pressed"]
 [connection signal="pressed" from="Main/Tabs/Fonts/FontSelection/LeftPane/BtnSaveFontOptions" to="Main/Tabs/Fonts" method="_on_BtnSaveFontOptions_pressed"]
+[connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnRefresh" to="Main/Tabs/Backups" method="_on_BtnRefresh_pressed"]
 [connection signal="pressed" from="Main/Tabs/Backups/Current/BtnCreate" to="Main/Tabs/Backups" method="_on_BtnCreate_pressed"]
 [connection signal="toggled" from="Main/Tabs/Settings/ShowGameDesc" to="Main/Tabs/Settings" method="_on_ShowGameDesc_toggled"]
 [connection signal="toggled" from="Main/Tabs/Settings/PrintTips" to="Main/Tabs/Settings" method="_on_PrintTips_toggled"]

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -1359,6 +1359,7 @@ __meta__ = {
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnRestore" to="Main/Tabs/Backups" method="_on_BtnRestore_pressed"]
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnDelete" to="Main/Tabs/Backups" method="_on_BtnDelete_pressed"]
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnRefresh" to="Main/Tabs/Backups" method="_on_BtnRefresh_pressed"]
+[connection signal="text_changed" from="Main/Tabs/Backups/Current/HBox/EditName" to="Main/Tabs/Backups" method="_on_EditName_text_changed"]
 [connection signal="pressed" from="Main/Tabs/Backups/Current/BtnCreate" to="Main/Tabs/Backups" method="_on_BtnCreate_pressed"]
 [connection signal="toggled" from="Main/Tabs/Settings/ShowGameDesc" to="Main/Tabs/Settings" method="_on_ShowGameDesc_toggled"]
 [connection signal="toggled" from="Main/Tabs/Settings/PrintTips" to="Main/Tabs/Settings" method="_on_PrintTips_toggled"]

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -1360,6 +1360,7 @@ __meta__ = {
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnDelete" to="Main/Tabs/Backups" method="_on_BtnDelete_pressed"]
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnRefresh" to="Main/Tabs/Backups" method="_on_BtnRefresh_pressed"]
 [connection signal="text_changed" from="Main/Tabs/Backups/Current/HBox/EditName" to="Main/Tabs/Backups" method="_on_EditName_text_changed"]
+[connection signal="text_entered" from="Main/Tabs/Backups/Current/HBox/EditName" to="Main/Tabs/Backups" method="_on_EditName_text_entered"]
 [connection signal="pressed" from="Main/Tabs/Backups/Current/BtnCreate" to="Main/Tabs/Backups" method="_on_BtnCreate_pressed"]
 [connection signal="toggled" from="Main/Tabs/Settings/ShowGameDesc" to="Main/Tabs/Settings" method="_on_ShowGameDesc_toggled"]
 [connection signal="toggled" from="Main/Tabs/Settings/PrintTips" to="Main/Tabs/Settings" method="_on_PrintTips_toggled"]

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=34 format=2]
+[gd_scene load_steps=36 format=2]
 
 [ext_resource path="res://icons/info.svg" type="Texture" id=1]
 [ext_resource path="res://icons/download.svg" type="Texture" id=2]
@@ -32,6 +32,8 @@
 [ext_resource path="res://icons/help.svg" type="Texture" id=30]
 [ext_resource path="res://scripts/PathHelper.gd" type="Script" id=31]
 [ext_resource path="res://scenes/ChangelogDialog.tscn" type="PackedScene" id=32]
+[ext_resource path="res://scripts/BackupsUI.gd" type="Script" id=33]
+[ext_resource path="res://scripts/BackupManager.gd" type="Script" id=34]
 
 [sub_resource type="ButtonGroup" id=1]
 
@@ -827,6 +829,7 @@ margin_left = 7.5
 margin_top = 38.5
 margin_right = -7.5
 margin_bottom = -7.5
+script = ExtResource( 33 )
 
 [node name="Available" type="VBoxContainer" parent="Main/Tabs/Backups"]
 margin_right = 769.0
@@ -1304,11 +1307,18 @@ __meta__ = {
 "_editor_description_": "The centralized location for all path resolutions in the launcher."
 }
 
+[node name="Backups" type="Node" parent="."]
+script = ExtResource( 34 )
+__meta__ = {
+"_editor_description_": "Provides backup management utilities"
+}
+
 [connection signal="meta_clicked" from="Main/GameInfo/Description" to="." method="_on_Description_meta_clicked"]
 [connection signal="tab_changed" from="Main/Tabs" to="." method="_on_Tabs_tab_changed"]
 [connection signal="tab_changed" from="Main/Tabs" to="Main/Tabs/Mods" method="_on_Tabs_tab_changed"]
 [connection signal="tab_changed" from="Main/Tabs" to="Main/Tabs/Soundpacks" method="_on_Tabs_tab_changed"]
 [connection signal="tab_changed" from="Main/Tabs" to="Main/Tabs/Fonts" method="_on_Tabs_tab_changed"]
+[connection signal="tab_changed" from="Main/Tabs" to="Main/Tabs/Backups" method="_on_Tabs_tab_changed"]
 [connection signal="item_selected" from="Main/Tabs/Game/Builds/BuildsList" to="." method="_on_BuildsList_item_selected"]
 [connection signal="pressed" from="Main/Tabs/Game/Builds/BtnRefresh" to="." method="_on_BtnRefresh_pressed"]
 [connection signal="pressed" from="Main/Tabs/Game/BtnInstall" to="." method="_on_BtnInstall_pressed"]
@@ -1346,6 +1356,7 @@ __meta__ = {
 [connection signal="toggled" from="Main/Tabs/Fonts/FontSelection/LeftPane/PreviewCyrillic" to="Main/Tabs/Fonts" method="_on_PreviewCyrillic_toggled"]
 [connection signal="pressed" from="Main/Tabs/Fonts/FontSelection/LeftPane/OtherSettings/HelpIcon" to="Main/Tabs/Fonts" method="_on_HelpIcon_pressed"]
 [connection signal="pressed" from="Main/Tabs/Fonts/FontSelection/LeftPane/BtnSaveFontOptions" to="Main/Tabs/Fonts" method="_on_BtnSaveFontOptions_pressed"]
+[connection signal="pressed" from="Main/Tabs/Backups/Current/BtnCreate" to="Main/Tabs/Backups" method="_on_BtnCreate_pressed"]
 [connection signal="toggled" from="Main/Tabs/Settings/ShowGameDesc" to="Main/Tabs/Settings" method="_on_ShowGameDesc_toggled"]
 [connection signal="toggled" from="Main/Tabs/Settings/PrintTips" to="Main/Tabs/Settings" method="_on_PrintTips_toggled"]
 [connection signal="toggled" from="Main/Tabs/Settings/UpdateToSame" to="Main/Tabs/Settings" method="_on_UpdateToSame_toggled"]
@@ -1400,3 +1411,4 @@ __meta__ = {
 [connection signal="status_message" from="Sound" to="." method="_on_status_message"]
 [connection signal="status_message" from="Fonts" to="." method="_on_status_message"]
 [connection signal="status_message" from="PathHelper" to="." method="_on_status_message"]
+[connection signal="status_message" from="Backups" to="." method="_on_status_message"]

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -1356,6 +1356,7 @@ __meta__ = {
 [connection signal="toggled" from="Main/Tabs/Fonts/FontSelection/LeftPane/PreviewCyrillic" to="Main/Tabs/Fonts" method="_on_PreviewCyrillic_toggled"]
 [connection signal="pressed" from="Main/Tabs/Fonts/FontSelection/LeftPane/OtherSettings/HelpIcon" to="Main/Tabs/Fonts" method="_on_HelpIcon_pressed"]
 [connection signal="pressed" from="Main/Tabs/Fonts/FontSelection/LeftPane/BtnSaveFontOptions" to="Main/Tabs/Fonts" method="_on_BtnSaveFontOptions_pressed"]
+[connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnRestore" to="Main/Tabs/Backups" method="_on_BtnRestore_pressed"]
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnRefresh" to="Main/Tabs/Backups" method="_on_BtnRefresh_pressed"]
 [connection signal="pressed" from="Main/Tabs/Backups/Current/BtnCreate" to="Main/Tabs/Backups" method="_on_BtnCreate_pressed"]
 [connection signal="toggled" from="Main/Tabs/Settings/ShowGameDesc" to="Main/Tabs/Settings" method="_on_ShowGameDesc_toggled"]

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -841,14 +841,29 @@ margin_bottom = 29.0
 text = "Save directory backups:"
 align = 1
 
-[node name="BackupsList" type="ItemList" parent="Main/Tabs/Backups/Available" groups=["disable_during_backup_operations"]]
+[node name="HBox" type="HBoxContainer" parent="Main/Tabs/Backups/Available"]
 margin_top = 35.0
 margin_right = 769.0
 margin_bottom = 235.0
+
+[node name="BackupsList" type="ItemList" parent="Main/Tabs/Backups/Available/HBox" groups=["disable_during_backup_operations"]]
+margin_right = 381.0
+margin_bottom = 200.0
 rect_min_size = Vector2( 0, 200 )
 size_flags_horizontal = 3
 items = [ "Item 0", null, false, "Item 1", null, false, "Item 2", null, false, "Item 3", null, false, "Item 4", null, false, "Item 5", null, false, "Item 6", null, false, "Item 7", null, false, "Item 8", null, false, "Item 9", null, false ]
 same_column_width = true
+
+[node name="BackupInfo" type="RichTextLabel" parent="Main/Tabs/Backups/Available/HBox"]
+margin_left = 387.0
+margin_right = 769.0
+margin_bottom = 200.0
+focus_mode = 2
+size_flags_horizontal = 3
+bbcode_enabled = true
+bbcode_text = "Backup details will appear here."
+text = "Backup details will appear here."
+selection_enabled = true
 
 [node name="Buttons" type="HBoxContainer" parent="Main/Tabs/Backups/Available"]
 margin_top = 241.0
@@ -1360,7 +1375,8 @@ __meta__ = {
 [connection signal="toggled" from="Main/Tabs/Fonts/FontSelection/LeftPane/PreviewCyrillic" to="Main/Tabs/Fonts" method="_on_PreviewCyrillic_toggled"]
 [connection signal="pressed" from="Main/Tabs/Fonts/FontSelection/LeftPane/OtherSettings/HelpIcon" to="Main/Tabs/Fonts" method="_on_HelpIcon_pressed"]
 [connection signal="pressed" from="Main/Tabs/Fonts/FontSelection/LeftPane/BtnSaveFontOptions" to="Main/Tabs/Fonts" method="_on_BtnSaveFontOptions_pressed"]
-[connection signal="item_selected" from="Main/Tabs/Backups/Available/BackupsList" to="Main/Tabs/Backups" method="_on_BackupsList_item_selected"]
+[connection signal="item_selected" from="Main/Tabs/Backups/Available/HBox/BackupsList" to="Main/Tabs/Backups" method="_on_BackupsList_item_selected"]
+[connection signal="meta_clicked" from="Main/Tabs/Backups/Available/HBox/BackupInfo" to="Main/Tabs/Backups" method="_on_BackupInfo_meta_clicked"]
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnRestore" to="Main/Tabs/Backups" method="_on_BtnRestore_pressed"]
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnDelete" to="Main/Tabs/Backups" method="_on_BtnDelete_pressed"]
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnRefresh" to="Main/Tabs/Backups" method="_on_BtnRefresh_pressed"]

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -819,6 +819,99 @@ margin_top = 538.0
 margin_right = 769.0
 margin_bottom = 539.0
 
+[node name="Backups" type="VBoxContainer" parent="Main/Tabs"]
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 7.5
+margin_top = 38.5
+margin_right = -7.5
+margin_bottom = -7.5
+
+[node name="Available" type="VBoxContainer" parent="Main/Tabs/Backups"]
+margin_right = 769.0
+margin_bottom = 270.0
+
+[node name="Label" type="Label" parent="Main/Tabs/Backups/Available"]
+margin_right = 769.0
+margin_bottom = 29.0
+text = "Available:"
+align = 1
+
+[node name="BackupsList" type="ItemList" parent="Main/Tabs/Backups/Available"]
+margin_top = 35.0
+margin_right = 769.0
+margin_bottom = 235.0
+rect_min_size = Vector2( 0, 200 )
+size_flags_horizontal = 3
+items = [ "Item 0", null, false, "Item 1", null, false, "Item 2", null, false, "Item 3", null, false, "Item 4", null, false, "Item 5", null, false, "Item 6", null, false, "Item 7", null, false, "Item 8", null, false, "Item 9", null, false ]
+same_column_width = true
+
+[node name="Buttons" type="HBoxContainer" parent="Main/Tabs/Backups/Available"]
+margin_top = 241.0
+margin_right = 769.0
+margin_bottom = 270.0
+alignment = 1
+
+[node name="BtnRestore" type="Button" parent="Main/Tabs/Backups/Available/Buttons"]
+margin_left = 268.0
+margin_right = 345.0
+margin_bottom = 29.0
+text = "Restore"
+
+[node name="BtnDelete" type="Button" parent="Main/Tabs/Backups/Available/Buttons"]
+margin_left = 351.0
+margin_right = 418.0
+margin_bottom = 29.0
+text = "Delete"
+
+[node name="BtnRefresh" type="Button" parent="Main/Tabs/Backups/Available/Buttons"]
+margin_left = 424.0
+margin_right = 500.0
+margin_bottom = 29.0
+text = "Refresh"
+
+[node name="HSeparator" type="HSeparator" parent="Main/Tabs/Backups"]
+margin_top = 276.0
+margin_right = 769.0
+margin_bottom = 284.0
+
+[node name="Current" type="VBoxContainer" parent="Main/Tabs/Backups"]
+margin_top = 290.0
+margin_right = 769.0
+margin_bottom = 389.0
+
+[node name="Label" type="Label" parent="Main/Tabs/Backups/Current"]
+margin_right = 769.0
+margin_bottom = 29.0
+text = "Manual Backup"
+align = 1
+
+[node name="HBox" type="HBoxContainer" parent="Main/Tabs/Backups/Current"]
+margin_top = 35.0
+margin_right = 769.0
+margin_bottom = 64.0
+
+[node name="Label" type="Label" parent="Main/Tabs/Backups/Current/HBox"]
+margin_right = 61.0
+margin_bottom = 29.0
+text = "Name:"
+
+[node name="EditName" type="LineEdit" parent="Main/Tabs/Backups/Current/HBox"]
+margin_left = 67.0
+margin_right = 769.0
+margin_bottom = 29.0
+size_flags_horizontal = 3
+placeholder_text = "Enter name for new backup"
+
+[node name="BtnCreate" type="Button" parent="Main/Tabs/Backups/Current"]
+margin_left = 350.0
+margin_top = 70.0
+margin_right = 418.0
+margin_bottom = 99.0
+size_flags_horizontal = 4
+text = "Create"
+
 [node name="Settings" type="VBoxContainer" parent="Main/Tabs"]
 visible = false
 anchor_right = 1.0

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -1357,6 +1357,7 @@ __meta__ = {
 [connection signal="pressed" from="Main/Tabs/Fonts/FontSelection/LeftPane/OtherSettings/HelpIcon" to="Main/Tabs/Fonts" method="_on_HelpIcon_pressed"]
 [connection signal="pressed" from="Main/Tabs/Fonts/FontSelection/LeftPane/BtnSaveFontOptions" to="Main/Tabs/Fonts" method="_on_BtnSaveFontOptions_pressed"]
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnRestore" to="Main/Tabs/Backups" method="_on_BtnRestore_pressed"]
+[connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnDelete" to="Main/Tabs/Backups" method="_on_BtnDelete_pressed"]
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnRefresh" to="Main/Tabs/Backups" method="_on_BtnRefresh_pressed"]
 [connection signal="pressed" from="Main/Tabs/Backups/Current/BtnCreate" to="Main/Tabs/Backups" method="_on_BtnCreate_pressed"]
 [connection signal="toggled" from="Main/Tabs/Settings/ShowGameDesc" to="Main/Tabs/Settings" method="_on_ShowGameDesc_toggled"]

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -1356,6 +1356,7 @@ __meta__ = {
 [connection signal="toggled" from="Main/Tabs/Fonts/FontSelection/LeftPane/PreviewCyrillic" to="Main/Tabs/Fonts" method="_on_PreviewCyrillic_toggled"]
 [connection signal="pressed" from="Main/Tabs/Fonts/FontSelection/LeftPane/OtherSettings/HelpIcon" to="Main/Tabs/Fonts" method="_on_HelpIcon_pressed"]
 [connection signal="pressed" from="Main/Tabs/Fonts/FontSelection/LeftPane/BtnSaveFontOptions" to="Main/Tabs/Fonts" method="_on_BtnSaveFontOptions_pressed"]
+[connection signal="item_selected" from="Main/Tabs/Backups/Available/BackupsList" to="Main/Tabs/Backups" method="_on_BackupsList_item_selected"]
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnRestore" to="Main/Tabs/Backups" method="_on_BtnRestore_pressed"]
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnDelete" to="Main/Tabs/Backups" method="_on_BtnDelete_pressed"]
 [connection signal="pressed" from="Main/Tabs/Backups/Available/Buttons/BtnRefresh" to="Main/Tabs/Backups" method="_on_BtnRefresh_pressed"]

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -117,7 +117,7 @@ margin_top = 91.0
 margin_right = 784.0
 margin_bottom = 91.0
 
-[node name="Tabs" type="TabContainer" parent="Main" groups=["disable_during_mod_operations", "disable_during_soundpack_operations", "disable_while_fetching_releases", "disable_while_installing_game"]]
+[node name="Tabs" type="TabContainer" parent="Main" groups=["disable_during_backup_operations", "disable_during_mod_operations", "disable_during_soundpack_operations", "disable_while_fetching_releases", "disable_while_installing_game"]]
 margin_top = 97.0
 margin_right = 784.0
 margin_bottom = 418.0
@@ -841,7 +841,7 @@ margin_bottom = 29.0
 text = "Available:"
 align = 1
 
-[node name="BackupsList" type="ItemList" parent="Main/Tabs/Backups/Available"]
+[node name="BackupsList" type="ItemList" parent="Main/Tabs/Backups/Available" groups=["disable_during_backup_operations"]]
 margin_top = 35.0
 margin_right = 769.0
 margin_bottom = 235.0
@@ -856,19 +856,19 @@ margin_right = 769.0
 margin_bottom = 270.0
 alignment = 1
 
-[node name="BtnRestore" type="Button" parent="Main/Tabs/Backups/Available/Buttons"]
+[node name="BtnRestore" type="Button" parent="Main/Tabs/Backups/Available/Buttons" groups=["disable_during_backup_operations"]]
 margin_left = 268.0
 margin_right = 345.0
 margin_bottom = 29.0
 text = "Restore"
 
-[node name="BtnDelete" type="Button" parent="Main/Tabs/Backups/Available/Buttons"]
+[node name="BtnDelete" type="Button" parent="Main/Tabs/Backups/Available/Buttons" groups=["disable_during_backup_operations"]]
 margin_left = 351.0
 margin_right = 418.0
 margin_bottom = 29.0
 text = "Delete"
 
-[node name="BtnRefresh" type="Button" parent="Main/Tabs/Backups/Available/Buttons"]
+[node name="BtnRefresh" type="Button" parent="Main/Tabs/Backups/Available/Buttons" groups=["disable_during_backup_operations"]]
 margin_left = 424.0
 margin_right = 500.0
 margin_bottom = 29.0
@@ -900,14 +900,14 @@ margin_right = 61.0
 margin_bottom = 29.0
 text = "Name:"
 
-[node name="EditName" type="LineEdit" parent="Main/Tabs/Backups/Current/HBox"]
+[node name="EditName" type="LineEdit" parent="Main/Tabs/Backups/Current/HBox" groups=["disable_during_backup_operations"]]
 margin_left = 67.0
 margin_right = 769.0
 margin_bottom = 29.0
 size_flags_horizontal = 3
 placeholder_text = "Enter name for new backup"
 
-[node name="BtnCreate" type="Button" parent="Main/Tabs/Backups/Current"]
+[node name="BtnCreate" type="Button" parent="Main/Tabs/Backups/Current" groups=["disable_during_backup_operations"]]
 margin_left = 350.0
 margin_top = 70.0
 margin_right = 418.0
@@ -1413,4 +1413,8 @@ __meta__ = {
 [connection signal="status_message" from="Sound" to="." method="_on_status_message"]
 [connection signal="status_message" from="Fonts" to="." method="_on_status_message"]
 [connection signal="status_message" from="PathHelper" to="." method="_on_status_message"]
+[connection signal="backup_creation_finished" from="Backups" to="." method="_on_backup_operation_finished"]
+[connection signal="backup_creation_started" from="Backups" to="." method="_on_backup_operation_started"]
+[connection signal="backup_restoration_finished" from="Backups" to="." method="_on_backup_operation_finished"]
+[connection signal="backup_restoration_started" from="Backups" to="." method="_on_backup_operation_started"]
 [connection signal="status_message" from="Backups" to="." method="_on_status_message"]

--- a/scripts/BackupManager.gd
+++ b/scripts/BackupManager.gd
@@ -29,3 +29,13 @@ func backup_current(backup_name: String) -> void:
 	yield(_fshelper, "move_dir_done")
 	
 	emit_signal("status_message", "Backup complete.")
+
+
+func get_available() -> Array:
+
+	var backups_dir = _workdir.plus_file(_settings.read("game")).plus_file(_BACKUPS_SUBDIR)
+	
+	if not Directory.new().dir_exists(backups_dir):
+		return []
+	
+	return _fshelper.list_dir(backups_dir)

--- a/scripts/BackupManager.gd
+++ b/scripts/BackupManager.gd
@@ -30,14 +30,18 @@ func backup_current(backup_name: String) -> void:
 	var source_dir = game_dir.plus_file("current").plus_file("save")
 	var dest_dir = game_dir.plus_file(_BACKUPS_SUBDIR).plus_file(backup_name)
 	
-	_fshelper.copy_dir(source_dir, temp_dir)
-	yield(_fshelper, "copy_dir_done")
+	if not Directory.new().dir_exists(dest_dir):
+		_fshelper.copy_dir(source_dir, temp_dir)
+		yield(_fshelper, "copy_dir_done")
+		
+		_fshelper.move_dir(temp_dir.plus_file("save"), dest_dir)
+		yield(_fshelper, "move_dir_done")
+		
+		emit_signal("status_message", "Backup created.")
+	else:
+		emit_signal("status_message", "A backup named \"%s\" already exists." % backup_name, Enums.MSG_ERROR)
 
-	_fshelper.move_dir(temp_dir.plus_file("save"), dest_dir)
-	yield(_fshelper, "move_dir_done")
-	
 	emit_signal("backup_creation_finished")
-	emit_signal("status_message", "Backup complete.")
 
 
 func get_available() -> Array:

--- a/scripts/BackupManager.gd
+++ b/scripts/BackupManager.gd
@@ -29,13 +29,13 @@ func backup_current(backup_name: String) -> void:
 	var temp_dir = _workdir.plus_file("tmp")
 	var source_dir = game_dir.plus_file("current").plus_file("save")
 	var dest_dir = game_dir.plus_file(_BACKUPS_SUBDIR).plus_file(backup_name)
+	var d = Directory.new()
 	
-	if not Directory.new().dir_exists(dest_dir):
-		_fshelper.copy_dir(source_dir, temp_dir)
-		yield(_fshelper, "copy_dir_done")
-		
-		_fshelper.move_dir(temp_dir.plus_file("save"), dest_dir)
-		yield(_fshelper, "move_dir_done")
+	if not d.dir_exists(dest_dir):
+		d.make_dir(dest_dir)
+		for world in _fshelper.list_dir(source_dir):
+			_fshelper.copy_dir(source_dir.plus_file(world), dest_dir)
+			yield(_fshelper, "copy_dir_done")
 		
 		emit_signal("status_message", "Backup created.")
 	else:
@@ -93,12 +93,11 @@ func restore(backup_name: String) -> void:
 		if Directory.new().dir_exists(dest_dir):
 			_fshelper.rm_dir(dest_dir)
 			yield(_fshelper, "rm_dir_done")
-			
-		_fshelper.copy_dir(source_dir, temp_dir)
-		yield(_fshelper, "copy_dir_done")
-
-		_fshelper.move_dir(temp_dir.plus_file(backup_name), dest_dir)
-		yield(_fshelper, "move_dir_done")
+		
+		Directory.new().make_dir(dest_dir)
+		for world in _fshelper.list_dir(source_dir):
+			_fshelper.copy_dir(source_dir.plus_file(world), dest_dir)
+			yield(_fshelper, "copy_dir_done")
 		
 		emit_signal("status_message", "Backup restored.")
 	else:

--- a/scripts/BackupManager.gd
+++ b/scripts/BackupManager.gd
@@ -2,6 +2,10 @@ extends Node
 
 
 signal status_message
+signal backup_creation_started
+signal backup_creation_finished
+signal backup_restoration_started
+signal backup_restoration_finished
 
 
 const _BACKUPS_SUBDIR = "save_backups"
@@ -16,6 +20,8 @@ func backup_current(backup_name: String) -> void:
 	# Create a backup of the save dir for the current game.
 
 	emit_signal("status_message", "Backing up current saves to %s..." % backup_name)
+	
+	emit_signal("backup_creation_started")
 
 	var game_dir = _workdir.plus_file(_settings.read("game"))
 	var temp_dir = _workdir.plus_file("tmp")
@@ -28,6 +34,7 @@ func backup_current(backup_name: String) -> void:
 	_fshelper.move_dir(temp_dir.plus_file("save"), dest_dir)
 	yield(_fshelper, "move_dir_done")
 	
+	emit_signal("backup_creation_finished")
 	emit_signal("status_message", "Backup complete.")
 
 
@@ -55,6 +62,8 @@ func restore(backup_name: String) -> void:
 		emit_signal("status_message", "Backup \"%s\" not found." % backup_name, Enums.MSG_ERROR)
 		return
 	
+	emit_signal("backup_restoration_started")
+
 	if Directory.new().dir_exists(dest_dir):
 		_fshelper.rm_dir(dest_dir)
 		yield(_fshelper, "rm_dir_done")
@@ -65,4 +74,5 @@ func restore(backup_name: String) -> void:
 	_fshelper.move_dir(temp_dir.plus_file(backup_name), dest_dir)
 	yield(_fshelper, "move_dir_done")
 	
+	emit_signal("backup_restoration_finished")
 	emit_signal("status_message", "Backup restored.")

--- a/scripts/BackupManager.gd
+++ b/scripts/BackupManager.gd
@@ -44,14 +44,37 @@ func backup_current(backup_name: String) -> void:
 	emit_signal("backup_creation_finished")
 
 
+func get_save_summary(path: String) -> Dictionary:
+	# Get information about a game save directory (any directory containing one or more game worlds)
+	
+	if not Directory.new().dir_exists(path):
+		return {}
+	
+	var summary = {
+		"name": path.get_file(),
+		"path": path,
+		"worlds": [],
+	}
+	
+	for world in _fshelper.list_dir(path):
+		summary["worlds"].append(world)
+	
+	return summary
+
+
 func get_available() -> Array:
 
 	var backups_dir = _workdir.plus_file(_settings.read("game")).plus_file(_BACKUPS_SUBDIR)
+	var out = []
 	
 	if not Directory.new().dir_exists(backups_dir):
-		return []
+		return out
 	
-	return _fshelper.list_dir(backups_dir)
+	for backup in _fshelper.list_dir(backups_dir):
+		var path = backups_dir.plus_file(backup)
+		out.append(get_save_summary(path))
+	
+	return out
 
 
 func restore(backup_name: String) -> void:

--- a/scripts/BackupManager.gd
+++ b/scripts/BackupManager.gd
@@ -39,3 +39,30 @@ func get_available() -> Array:
 		return []
 	
 	return _fshelper.list_dir(backups_dir)
+
+
+func restore(backup_name: String) -> void:
+	# Replace the save dir in the current game with the named backup
+	
+	emit_signal("status_message", "Restoring backup \"%s\"..." % backup_name)
+	
+	var game_dir = _workdir.plus_file(_settings.read("game"))
+	var temp_dir = _workdir.plus_file("tmp")
+	var source_dir = game_dir.plus_file(_BACKUPS_SUBDIR).plus_file(backup_name)
+	var dest_dir = game_dir.plus_file("current").plus_file("save")
+	
+	if not Directory.new().dir_exists(source_dir):
+		emit_signal("status_message", "Backup \"%s\" not found." % backup_name, Enums.MSG_ERROR)
+		return
+	
+	if Directory.new().dir_exists(dest_dir):
+		_fshelper.rm_dir(dest_dir)
+		yield(_fshelper, "rm_dir_done")
+		
+	_fshelper.copy_dir(source_dir, temp_dir)
+	yield(_fshelper, "copy_dir_done")
+
+	_fshelper.move_dir(temp_dir.plus_file(backup_name), dest_dir)
+	yield(_fshelper, "move_dir_done")
+	
+	emit_signal("status_message", "Backup restored.")

--- a/scripts/BackupManager.gd
+++ b/scripts/BackupManager.gd
@@ -6,6 +6,8 @@ signal backup_creation_started
 signal backup_creation_finished
 signal backup_restoration_started
 signal backup_restoration_finished
+signal backup_deletion_started
+signal backup_deletion_finished
 
 
 const _BACKUPS_SUBDIR = "save_backups"
@@ -76,3 +78,20 @@ func restore(backup_name: String) -> void:
 	
 	emit_signal("backup_restoration_finished")
 	emit_signal("status_message", "Backup restored.")
+
+
+func delete(backup_name: String) -> void:
+	# Delete a backup.
+	
+	var target_dir = _workdir.plus_file(_settings.read("game")).plus_file(_BACKUPS_SUBDIR).plus_file(backup_name)
+	if not Directory.new().dir_exists(target_dir):
+		return
+	
+	emit_signal("status_message", "Deleting backup \"%s\"..." % backup_name)
+	emit_signal("backup_deletion_started")
+	
+	_fshelper.rm_dir(target_dir)
+	yield(_fshelper, "rm_dir_done")
+	
+	emit_signal("backup_deletion_finished")
+	emit_signal("status_message", "Backup deleted.")

--- a/scripts/BackupManager.gd
+++ b/scripts/BackupManager.gd
@@ -1,0 +1,31 @@
+extends Node
+
+
+signal status_message
+
+
+const _BACKUPS_SUBDIR = "save_backups"
+
+onready var _settings = $"/root/SettingsManager"
+onready var _fshelper = $"../FSHelper"
+
+onready var _workdir = OS.get_executable_path().get_base_dir()
+
+
+func backup_current(backup_name: String) -> void:
+	# Create a backup of the save dir for the current game.
+
+	emit_signal("status_message", "Backing up current saves to %s..." % backup_name)
+
+	var game_dir = _workdir.plus_file(_settings.read("game"))
+	var temp_dir = _workdir.plus_file("tmp")
+	var source_dir = game_dir.plus_file("current").plus_file("save")
+	var dest_dir = game_dir.plus_file(_BACKUPS_SUBDIR).plus_file(backup_name)
+	
+	_fshelper.copy_dir(source_dir, temp_dir)
+	yield(_fshelper, "copy_dir_done")
+
+	_fshelper.move_dir(temp_dir.plus_file("save"), dest_dir)
+	yield(_fshelper, "move_dir_done")
+	
+	emit_signal("status_message", "Backup complete.")

--- a/scripts/BackupManager.gd
+++ b/scripts/BackupManager.gd
@@ -60,38 +60,37 @@ func restore(backup_name: String) -> void:
 	var source_dir = game_dir.plus_file(_BACKUPS_SUBDIR).plus_file(backup_name)
 	var dest_dir = game_dir.plus_file("current").plus_file("save")
 	
-	if not Directory.new().dir_exists(source_dir):
-		emit_signal("status_message", "Backup \"%s\" not found." % backup_name, Enums.MSG_ERROR)
-		return
-	
 	emit_signal("backup_restoration_started")
 
-	if Directory.new().dir_exists(dest_dir):
-		_fshelper.rm_dir(dest_dir)
-		yield(_fshelper, "rm_dir_done")
-		
-	_fshelper.copy_dir(source_dir, temp_dir)
-	yield(_fshelper, "copy_dir_done")
+	if Directory.new().dir_exists(source_dir):
+		if Directory.new().dir_exists(dest_dir):
+			_fshelper.rm_dir(dest_dir)
+			yield(_fshelper, "rm_dir_done")
+			
+		_fshelper.copy_dir(source_dir, temp_dir)
+		yield(_fshelper, "copy_dir_done")
 
-	_fshelper.move_dir(temp_dir.plus_file(backup_name), dest_dir)
-	yield(_fshelper, "move_dir_done")
+		_fshelper.move_dir(temp_dir.plus_file(backup_name), dest_dir)
+		yield(_fshelper, "move_dir_done")
+		
+		emit_signal("status_message", "Backup restored.")
+	else:
+		emit_signal("status_message", "Backup \"%s\" not found." % backup_name, Enums.MSG_ERROR)
 	
 	emit_signal("backup_restoration_finished")
-	emit_signal("status_message", "Backup restored.")
 
 
 func delete(backup_name: String) -> void:
 	# Delete a backup.
 	
 	var target_dir = _workdir.plus_file(_settings.read("game")).plus_file(_BACKUPS_SUBDIR).plus_file(backup_name)
-	if not Directory.new().dir_exists(target_dir):
-		return
-	
-	emit_signal("status_message", "Deleting backup \"%s\"..." % backup_name)
 	emit_signal("backup_deletion_started")
+
+	if Directory.new().dir_exists(target_dir):
+		emit_signal("status_message", "Deleting backup \"%s\"..." % backup_name)
 	
-	_fshelper.rm_dir(target_dir)
-	yield(_fshelper, "rm_dir_done")
-	
+		_fshelper.rm_dir(target_dir)
+		yield(_fshelper, "rm_dir_done")
+		emit_signal("status_message", "Backup deleted.")
+
 	emit_signal("backup_deletion_finished")
-	emit_signal("status_message", "Backup deleted.")

--- a/scripts/BackupsUI.gd
+++ b/scripts/BackupsUI.gd
@@ -27,7 +27,7 @@ func _on_Tabs_tab_changed(tab: int) -> void:
 func _on_BtnCreate_pressed():
 
 	var target_file = _edit_name.text
-	if target_file != "":
+	if target_file.is_valid_filename():
 		_backups.backup_current(target_file)
 		yield(_backups, "backup_creation_finished")
 		_refresh_available()
@@ -59,3 +59,16 @@ func _on_BtnDelete_pressed():
 		_backups.delete(selection)
 		yield(_backups, "backup_deletion_finished")
 		_refresh_available()
+
+
+func _on_EditName_text_changed(new_text: String):
+	
+	# This disallows Windows' invalid characters as well as text that is empty or has leading or
+	# trailing whitespace. These rules are used regardless of the active OS.
+	_btn_create.disabled = not new_text.is_valid_filename()
+	
+	# Keep normal color if text is empty to avoid red placeholder text.
+	if new_text == "" or new_text.is_valid_filename():
+		_edit_name.add_color_override("font_color", get_color("font_color", "LineEdit"))
+	else:
+		_edit_name.add_color_override("font_color", Color.red)

--- a/scripts/BackupsUI.gd
+++ b/scripts/BackupsUI.gd
@@ -17,7 +17,7 @@ func _refresh_available() -> void:
 	_btn_delete.disabled = true
 
 	for item in _backups.get_available():
-		_list_backups.add_item(item)
+		_list_backups.add_item(item["name"])
 
 
 func _on_Tabs_tab_changed(tab: int) -> void:

--- a/scripts/BackupsUI.gd
+++ b/scripts/BackupsUI.gd
@@ -29,6 +29,8 @@ func _on_BtnCreate_pressed():
 	var target_file = _edit_name.text
 	if target_file != "":
 		_backups.backup_current(target_file)
+		yield(_backups, "backup_creation_finished")
+		_refresh_available()
 
 
 func _on_BtnRefresh_pressed():

--- a/scripts/BackupsUI.gd
+++ b/scripts/BackupsUI.gd
@@ -7,11 +7,15 @@ onready var _btn_create = $Current/BtnCreate
 onready var _list_backups = $Available/BackupsList
 onready var _btn_refresh = $Available/Buttons/BtnRefresh
 onready var _btn_restore = $Available/Buttons/BtnRestore
+onready var _btn_delete = $Available/Buttons/BtnDelete
 
 
 func _refresh_available() -> void:
 	
 	_list_backups.clear()
+	_btn_restore.disabled = true
+	_btn_delete.disabled = true
+
 	for item in _backups.get_available():
 		_list_backups.add_item(item)
 
@@ -77,3 +81,9 @@ func _on_EditName_text_changed(new_text: String):
 		_edit_name.add_color_override("font_color", get_color("font_color", "LineEdit"))
 	else:
 		_edit_name.add_color_override("font_color", Color.red)
+
+
+func _on_BackupsList_item_selected(index):
+	
+	_btn_restore.disabled = false
+	_btn_delete.disabled = false

--- a/scripts/BackupsUI.gd
+++ b/scripts/BackupsUI.gd
@@ -3,7 +3,7 @@ extends VBoxContainer
 
 onready var _backups = $"/root/Catapult/Backups"
 onready var _edit_name = $Current/HBox/EditName
-onready var _btn_create = $Current/BtnCreate
+onready var _btn_create = $Current/HBox/BtnCreate
 onready var _list_backups = $Available/BackupsList
 onready var _btn_refresh = $Available/Buttons/BtnRefresh
 onready var _btn_restore = $Available/Buttons/BtnRestore
@@ -23,10 +23,10 @@ func _refresh_available() -> void:
 func _populate_default_new_name() -> void:
 	
 	var datetime = OS.get_datetime()
-	_edit_name.text = "Manual_%02d%02d%02d" % [
+	_edit_name.text = "Manual_%02d-%02d-%02d" % [
 		datetime["year"] % 100,
 		datetime["month"],
-		datetime["day"],
+		datetime["day"]
 	]
 
 
@@ -88,7 +88,7 @@ func _on_EditName_text_changed(new_text: String):
 	_btn_create.disabled = not new_text.is_valid_filename()
 	
 	# Keep normal color if text is empty to avoid red placeholder text.
-	if new_text == "" or new_text.is_valid_filename():
+	if (new_text == "") or (new_text.is_valid_filename()):
 		_edit_name.add_color_override("font_color", get_color("font_color", "LineEdit"))
 	else:
 		_edit_name.add_color_override("font_color", Color.red)

--- a/scripts/BackupsUI.gd
+++ b/scripts/BackupsUI.gd
@@ -46,3 +46,16 @@ func _on_BtnRestore_pressed():
 	var selection = _list_backups.get_item_text(_list_backups.get_selected_items()[0])
 	if selection != "":
 		_backups.restore(selection)
+
+
+func _on_BtnDelete_pressed():
+	
+	if not _list_backups.is_anything_selected():
+		return
+	
+	var selection = _list_backups.get_item_text(_list_backups.get_selected_items()[0])
+
+	if selection != "":
+		_backups.delete(selection)
+		yield(_backups, "backup_deletion_finished")
+		_refresh_available()

--- a/scripts/BackupsUI.gd
+++ b/scripts/BackupsUI.gd
@@ -20,12 +20,23 @@ func _refresh_available() -> void:
 		_list_backups.add_item(item["name"])
 
 
+func _populate_default_new_name() -> void:
+	
+	var datetime = OS.get_datetime()
+	_edit_name.text = "Manual_%02d%02d%02d" % [
+		datetime["year"] % 100,
+		datetime["month"],
+		datetime["day"],
+	]
+
+
 func _on_Tabs_tab_changed(tab: int) -> void:
 	
 	if tab != 4:
 		return
 	
 	_refresh_available()
+	_populate_default_new_name()
 
 
 func _on_BtnCreate_pressed():

--- a/scripts/BackupsUI.gd
+++ b/scripts/BackupsUI.gd
@@ -6,6 +6,7 @@ onready var _edit_name = $Current/HBox/EditName
 onready var _btn_create = $Current/BtnCreate
 onready var _list_backups = $Available/BackupsList
 onready var _btn_refresh = $Available/Buttons/BtnRefresh
+onready var _btn_restore = $Available/Buttons/BtnRestore
 
 
 func _refresh_available() -> void:
@@ -33,3 +34,13 @@ func _on_BtnCreate_pressed():
 func _on_BtnRefresh_pressed():
 
 	_refresh_available()
+
+
+func _on_BtnRestore_pressed():
+
+	if not _list_backups.is_anything_selected():
+		return
+	
+	var selection = _list_backups.get_item_text(_list_backups.get_selected_items()[0])
+	if selection != "":
+		_backups.restore(selection)

--- a/scripts/BackupsUI.gd
+++ b/scripts/BackupsUI.gd
@@ -1,0 +1,13 @@
+extends VBoxContainer
+
+
+onready var _backups = $"/root/Catapult/Backups"
+onready var _edit_name = $Current/HBox/EditName
+onready var _btn_create = $Current/BtnCreate
+
+
+func _on_BtnCreate_pressed():
+
+	var target_file = _edit_name.text
+	if target_file != "":
+		_backups.backup_current(target_file)

--- a/scripts/BackupsUI.gd
+++ b/scripts/BackupsUI.gd
@@ -4,6 +4,23 @@ extends VBoxContainer
 onready var _backups = $"/root/Catapult/Backups"
 onready var _edit_name = $Current/HBox/EditName
 onready var _btn_create = $Current/BtnCreate
+onready var _list_backups = $Available/BackupsList
+onready var _btn_refresh = $Available/Buttons/BtnRefresh
+
+
+func _refresh_available() -> void:
+	
+	_list_backups.clear()
+	for item in _backups.get_available():
+		_list_backups.add_item(item)
+
+
+func _on_Tabs_tab_changed(tab: int) -> void:
+	
+	if tab != 4:
+		return
+	
+	_refresh_available()
 
 
 func _on_BtnCreate_pressed():
@@ -11,3 +28,8 @@ func _on_BtnCreate_pressed():
 	var target_file = _edit_name.text
 	if target_file != "":
 		_backups.backup_current(target_file)
+
+
+func _on_BtnRefresh_pressed():
+
+	_refresh_available()

--- a/scripts/BackupsUI.gd
+++ b/scripts/BackupsUI.gd
@@ -4,10 +4,11 @@ extends VBoxContainer
 onready var _backups = $"/root/Catapult/Backups"
 onready var _edit_name = $Current/HBox/EditName
 onready var _btn_create = $Current/HBox/BtnCreate
-onready var _list_backups = $Available/BackupsList
+onready var _list_backups = $Available/HBox/BackupsList
 onready var _btn_refresh = $Available/Buttons/BtnRefresh
 onready var _btn_restore = $Available/Buttons/BtnRestore
 onready var _btn_delete = $Available/Buttons/BtnDelete
+onready var _lbl_info = $Available/HBox/BackupInfo
 
 
 func _refresh_available() -> void:
@@ -15,8 +16,10 @@ func _refresh_available() -> void:
 	_list_backups.clear()
 	_btn_restore.disabled = true
 	_btn_delete.disabled = true
+	_lbl_info.bbcode_text = "Select an existing backup to see its details here."
+	_backups.refresh_available()
 
-	for item in _backups.get_available():
+	for item in _backups.available:
 		_list_backups.add_item(item["name"])
 
 
@@ -63,9 +66,8 @@ func _on_BtnRestore_pressed():
 	if not _list_backups.is_anything_selected():
 		return
 	
-	var selection = _list_backups.get_item_text(_list_backups.get_selected_items()[0])
-	if selection != "":
-		_backups.restore(selection)
+	var idx = _list_backups.get_selected_items()[0]
+	_backups.restore(idx)
 
 
 func _on_BtnDelete_pressed():
@@ -98,3 +100,25 @@ func _on_BackupsList_item_selected(index):
 	
 	_btn_restore.disabled = false
 	_btn_delete.disabled = false
+	_lbl_info.bbcode_text = _make_backup_info_string(index)
+
+
+func _make_backup_info_string(index: int) -> String:
+	
+	var text := ""
+	var info: Dictionary = _backups.available[index]
+	
+	var worlds_str := ""
+	for world in info["worlds"]:
+		worlds_str += world + ", "
+	worlds_str = worlds_str.substr(0, len(worlds_str) - 2)
+	
+	text += "[u]Location:[/u]\n[color=#3b93f7][url=%s]%s[/url][/color]\n\n" % [info["path"], info["path"]]
+	text += "[u]Worlds:[/u]\n%s" % worlds_str
+	
+	return text
+
+
+func _on_BackupInfo_meta_clicked(meta) -> void:
+	
+	OS.shell_open(meta)

--- a/scripts/BackupsUI.gd
+++ b/scripts/BackupsUI.gd
@@ -33,6 +33,11 @@ func _on_BtnCreate_pressed():
 		_refresh_available()
 
 
+func _on_EditName_text_entered(new_text):
+	
+	_on_BtnCreate_pressed()
+
+
 func _on_BtnRefresh_pressed():
 
 	_refresh_available()

--- a/scripts/Catapult.gd
+++ b/scripts/Catapult.gd
@@ -269,6 +269,16 @@ func _on_soundpack_operation_finished() -> void:
 	_smart_reenable_controls("disable_during_soundpack_operations")
 
 
+func _on_backup_operation_started() -> void:
+	
+	_smart_disable_controls("disable_during_backup_operations")
+
+
+func _on_backup_operation_finished() -> void:
+	
+	_smart_reenable_controls("disable_during_backup_operations")
+
+
 func _on_Description_meta_clicked(meta) -> void:
 	
 	if meta == "CHANGELOG":

--- a/scripts/Catapult.gd
+++ b/scripts/Catapult.gd
@@ -422,5 +422,5 @@ func _refresh_currently_installed() -> void:
 		_btn_play.disabled = true
 		_btn_game_dir.visible = false
 		
-	for i in [1, 2, 3]:
+	for i in [1, 2, 3, 4]:
 		_tabs.set_tab_disabled(i, not _is_selected_game_installed())


### PR DESCRIPTION
This adds a `Backups` tab that allows manually creating, restoring, and deleting copies of the save directory for each game. Should be a decent foundation for automated backups but wanted to see what you thought before changing too much.
