### PR TITLE
Change scaling method + many UI tweaks

### DIFF
--- a/fonts/OpenSans-Italic.tres
+++ b/fonts/OpenSans-Italic.tres
@@ -3,6 +3,7 @@
 [ext_resource path="res://fonts/OpenSans-Italic.ttf" type="DynamicFontData" id=1]
 
 [resource]
+size = 14
 extra_spacing_top = -3
 extra_spacing_bottom = -3
 font_data = ExtResource( 1 )

--- a/fonts/OpenSans-Italic.tres
+++ b/fonts/OpenSans-Italic.tres
@@ -3,7 +3,7 @@
 [ext_resource path="res://fonts/OpenSans-Italic.ttf" type="DynamicFontData" id=1]
 
 [resource]
-size = 14
+size = 13
 extra_spacing_top = -3
 extra_spacing_bottom = -3
 font_data = ExtResource( 1 )

--- a/fonts/OpenSans-Regular.tres
+++ b/fonts/OpenSans-Regular.tres
@@ -3,6 +3,7 @@
 [ext_resource path="res://fonts/OpenSans-Regular.ttf" type="DynamicFontData" id=1]
 
 [resource]
+size = 14
 extra_spacing_top = -3
 extra_spacing_bottom = -3
 font_data = ExtResource( 1 )

--- a/fonts/OpenSans-Regular.tres
+++ b/fonts/OpenSans-Regular.tres
@@ -3,7 +3,7 @@
 [ext_resource path="res://fonts/OpenSans-Regular.ttf" type="DynamicFontData" id=1]
 
 [resource]
-size = 14
+size = 13
 extra_spacing_top = -3
 extra_spacing_bottom = -3
 font_data = ExtResource( 1 )

--- a/fonts/OpenSans-Semibold.tres
+++ b/fonts/OpenSans-Semibold.tres
@@ -3,7 +3,7 @@
 [ext_resource path="res://fonts/OpenSans-Semibold.ttf" type="DynamicFontData" id=1]
 
 [resource]
-size = 14
+size = 13
 extra_spacing_top = -3
 extra_spacing_bottom = -3
 font_data = ExtResource( 1 )

--- a/fonts/OpenSans-Semibold.tres
+++ b/fonts/OpenSans-Semibold.tres
@@ -3,6 +3,7 @@
 [ext_resource path="res://fonts/OpenSans-Semibold.ttf" type="DynamicFontData" id=1]
 
 [resource]
+size = 14
 extra_spacing_top = -3
 extra_spacing_bottom = -3
 font_data = ExtResource( 1 )

--- a/fonts/OpenSans-SemiboldItalic.tres
+++ b/fonts/OpenSans-SemiboldItalic.tres
@@ -3,7 +3,7 @@
 [ext_resource path="res://fonts/OpenSans-SemiboldItalic.ttf" type="DynamicFontData" id=1]
 
 [resource]
-size = 14
+size = 13
 extra_spacing_top = -3
 extra_spacing_bottom = -3
 font_data = ExtResource( 1 )

--- a/fonts/OpenSans-SemiboldItalic.tres
+++ b/fonts/OpenSans-SemiboldItalic.tres
@@ -3,6 +3,7 @@
 [ext_resource path="res://fonts/OpenSans-SemiboldItalic.ttf" type="DynamicFontData" id=1]
 
 [resource]
+size = 14
 extra_spacing_top = -3
 extra_spacing_bottom = -3
 font_data = ExtResource( 1 )

--- a/project.godot
+++ b/project.godot
@@ -53,8 +53,8 @@ WindowGeometry="*res://scripts/window_geometry.gd"
 
 [display]
 
-window/size/width=650
-window/size/height=800
+window/size/width=600
+window/size/height=700
 window/size/resizable=false
 window/size/borderless=true
 window/size/test_width=1

--- a/project.godot
+++ b/project.godot
@@ -62,6 +62,7 @@ window/size/test_height=1
 window/dpi/allow_hidpi=true
 window/per_pixel_transparency/allowed=true
 window/per_pixel_transparency/enabled=true
+window/stretch/mode="2d"
 
 [gdnative]
 

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=39 format=2]
+[gd_scene load_steps=35 format=2]
 
 [ext_resource path="res://icons/info.svg" type="Texture" id=1]
 [ext_resource path="res://icons/download.svg" type="Texture" id=2]
@@ -6,7 +6,6 @@
 [ext_resource path="res://scripts/Catapult.gd" type="Script" id=4]
 [ext_resource path="res://scripts/ReleaseManager.gd" type="Script" id=5]
 [ext_resource path="res://scripts/InstallProbe.gd" type="Script" id=6]
-[ext_resource path="res://fonts/OpenSans-Regular.tres" type="DynamicFont" id=7]
 [ext_resource path="res://scripts/SettingsUI.gd" type="Script" id=8]
 [ext_resource path="res://scripts/ReleaseInstaller.gd" type="Script" id=9]
 [ext_resource path="res://scripts/DownloadManager.gd" type="Script" id=10]
@@ -21,9 +20,6 @@
 [ext_resource path="res://scripts/TOTD.gd" type="Script" id=19]
 [ext_resource path="res://scenes/ModReinstallDialog.tscn" type="PackedScene" id=20]
 [ext_resource path="res://themes/Godot_3.tres" type="Theme" id=21]
-[ext_resource path="res://fonts/OpenSans-Semibold.tres" type="DynamicFont" id=22]
-[ext_resource path="res://fonts/OpenSans-Italic.tres" type="DynamicFont" id=23]
-[ext_resource path="res://fonts/OpenSans-SemiboldItalic.tres" type="DynamicFont" id=24]
 [ext_resource path="res://icons/folder.svg" type="Texture" id=25]
 [ext_resource path="res://scenes/InlineIconButton.tscn" type="PackedScene" id=26]
 [ext_resource path="res://scripts/FontsUI.gd" type="Script" id=27]
@@ -68,17 +64,17 @@ __meta__ = {
 
 [node name="GameChoice" type="HBoxContainer" parent="Main"]
 margin_right = 634.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 
 [node name="Label" type="Label" parent="Main/GameChoice"]
-margin_right = 79.0
-margin_bottom = 29.0
+margin_right = 72.0
+margin_bottom = 26.0
 text = "lbl_game"
 
 [node name="GamesList" type="OptionButton" parent="Main/GameChoice" groups=["disable_during_mod_operations", "disable_during_soundpack_operations", "disable_while_fetching_releases", "disable_while_installing_game"]]
-margin_left = 85.0
+margin_left = 78.0
 margin_right = 634.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 hint_tooltip = "tooltip_game"
 size_flags_horizontal = 3
 text = "Cataclysm: Dark Days Ahead"
@@ -86,19 +82,19 @@ items = [ "Cataclysm: Dark Days Ahead", null, false, 0, null, "Cataclysm: Bright
 selected = 0
 
 [node name="GameInfo" type="HBoxContainer" parent="Main"]
-margin_top = 33.0
+margin_top = 30.0
 margin_right = 634.0
-margin_bottom = 83.0
+margin_bottom = 74.0
 custom_constants/separation = 8
 
 [node name="Spacer" type="Control" parent="Main/GameInfo"]
-margin_bottom = 50.0
+margin_bottom = 44.0
 
 [node name="Icon" type="TextureRect" parent="Main/GameInfo"]
 margin_left = 8.0
-margin_top = 9.0
+margin_top = 6.0
 margin_right = 40.0
-margin_bottom = 41.0
+margin_bottom = 38.0
 rect_min_size = Vector2( 32, 32 )
 size_flags_horizontal = 4
 size_flags_vertical = 4
@@ -109,27 +105,23 @@ stretch_mode = 6
 [node name="Description" type="RichTextLabel" parent="Main/GameInfo"]
 margin_left = 48.0
 margin_right = 634.0
-margin_bottom = 50.0
+margin_bottom = 44.0
 size_flags_horizontal = 3
 size_flags_vertical = 4
-custom_fonts/bold_italics_font = ExtResource( 24 )
-custom_fonts/italics_font = ExtResource( 23 )
-custom_fonts/bold_font = ExtResource( 22 )
-custom_fonts/normal_font = ExtResource( 7 )
 bbcode_enabled = true
 bbcode_text = "[b]Game Title[/b] is a game in which... and other stuff about the game. This is just a placeholder. At runtime, a proper description will be loaded here."
 text = "Game Title is a game in which... and other stuff about the game. This is just a placeholder. At runtime, a proper description will be loaded here."
 fit_content_height = true
 
 [node name="Spacer" type="Control" parent="Main"]
-margin_top = 87.0
+margin_top = 78.0
 margin_right = 634.0
-margin_bottom = 87.0
+margin_bottom = 78.0
 
 [node name="Tabs" type="TabContainer" parent="Main" groups=["disable_during_backup_operations", "disable_during_mod_operations", "disable_during_soundpack_operations", "disable_while_fetching_releases", "disable_while_installing_game"]]
-margin_top = 91.0
+margin_top = 82.0
 margin_right = 634.0
-margin_bottom = 600.0
+margin_bottom = 565.0
 tab_align = 0
 script = ExtResource( 16 )
 
@@ -138,28 +130,28 @@ visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
-margin_top = 38.5
+margin_top = 35.5
 margin_right = -7.5
 margin_bottom = -7.5
 custom_constants/separation = 8
 
 [node name="Channel" type="VBoxContainer" parent="Main/Tabs/Game"]
 margin_right = 619.0
-margin_bottom = 64.0
+margin_bottom = 60.0
 
 [node name="HBox" type="HBoxContainer" parent="Main/Tabs/Game/Channel"]
 margin_right = 619.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Game/Channel/HBox"]
-margin_right = 97.0
-margin_bottom = 29.0
+margin_right = 89.0
+margin_bottom = 26.0
 text = "lbl_channel"
 
 [node name="ChangelogLink" type="RichTextLabel" parent="Main/Tabs/Game/Channel/HBox"]
-margin_left = 103.0
+margin_left = 95.0
 margin_right = 619.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 rect_min_size = Vector2( 300, 0 )
 hint_tooltip = "tooltip_changelog"
 size_flags_horizontal = 3
@@ -169,56 +161,56 @@ text = "lbl_changelog"
 scroll_active = false
 
 [node name="Group" type="HBoxContainer" parent="Main/Tabs/Game/Channel"]
-margin_top = 35.0
+margin_top = 32.0
 margin_right = 619.0
-margin_bottom = 64.0
+margin_bottom = 60.0
 
 [node name="RBtnStable" type="CheckBox" parent="Main/Tabs/Game/Channel/Group" groups=["disable_while_fetching_releases", "disable_while_installing_game"]]
-margin_right = 120.0
-margin_bottom = 29.0
+margin_right = 110.0
+margin_bottom = 28.0
 hint_tooltip = "tooltip_stable"
 group = SubResource( 1 )
 text = "rbtn_stable"
 
 [node name="RBtnExperimental" type="CheckBox" parent="Main/Tabs/Game/Channel/Group" groups=["disable_while_fetching_releases", "disable_while_installing_game"]]
-margin_left = 126.0
-margin_right = 300.0
-margin_bottom = 29.0
+margin_left = 116.0
+margin_right = 274.0
+margin_bottom = 28.0
 hint_tooltip = "tooltip_experimental"
 pressed = true
 group = SubResource( 1 )
 text = "rbtn_experimental"
 
 [node name="Builds" type="HBoxContainer" parent="Main/Tabs/Game"]
-margin_top = 72.0
+margin_top = 68.0
 margin_right = 619.0
-margin_bottom = 101.0
+margin_bottom = 94.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Game/Builds"]
-margin_right = 83.0
-margin_bottom = 29.0
+margin_right = 77.0
+margin_bottom = 26.0
 text = "lbl_builds"
 
 [node name="BuildsList" type="OptionButton" parent="Main/Tabs/Game/Builds" groups=["disable_while_fetching_releases", "disable_while_installing_game"]]
-margin_left = 89.0
-margin_right = 507.0
-margin_bottom = 29.0
+margin_left = 83.0
+margin_right = 517.0
+margin_bottom = 26.0
 hint_tooltip = "tooltip_builds"
 size_flags_horizontal = 3
 clip_text = true
 
 [node name="BtnRefresh" type="Button" parent="Main/Tabs/Game/Builds" groups=["disable_while_fetching_releases", "disable_while_installing_game"]]
-margin_left = 513.0
+margin_left = 523.0
 margin_right = 619.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 hint_tooltip = "tooltip_refresh"
 text = "btn_refresh"
 
 [node name="BtnInstall" type="Button" parent="Main/Tabs/Game" groups=["disable_while_fetching_releases", "disable_while_installing_game"]]
 margin_left = 189.0
-margin_top = 109.0
+margin_top = 102.0
 margin_right = 429.0
-margin_bottom = 141.0
+margin_bottom = 134.0
 rect_min_size = Vector2( 240, 32 )
 hint_tooltip = "tooltip_install"
 size_flags_horizontal = 4
@@ -227,48 +219,48 @@ icon = ExtResource( 2 )
 expand_icon = true
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Game"]
-margin_top = 149.0
+margin_top = 142.0
 margin_right = 619.0
-margin_bottom = 157.0
+margin_bottom = 150.0
 
 [node name="CurrentInstall" type="VBoxContainer" parent="Main/Tabs/Game"]
-margin_top = 165.0
+margin_top = 158.0
 margin_right = 619.0
-margin_bottom = 267.0
+margin_bottom = 254.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Game/CurrentInstall"]
 margin_right = 619.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 text = "lbl_currently_installed"
 align = 1
 
 [node name="Build" type="HBoxContainer" parent="Main/Tabs/Game/CurrentInstall"]
-margin_left = 238.0
-margin_top = 35.0
-margin_right = 381.0
-margin_bottom = 64.0
+margin_left = 243.0
+margin_top = 32.0
+margin_right = 375.0
+margin_bottom = 58.0
 size_flags_horizontal = 4
 custom_constants/separation = 4
 
 [node name="Name" type="Label" parent="Main/Tabs/Game/CurrentInstall/Build"]
-margin_right = 121.0
-margin_bottom = 29.0
+margin_right = 110.0
+margin_bottom = 26.0
 text = "lbl_build_none"
 align = 1
 
 [node name="GameDir" parent="Main/Tabs/Game/CurrentInstall/Build" instance=ExtResource( 26 )]
-margin_left = 125.0
-margin_top = 5.0
-margin_right = 143.0
-margin_bottom = 23.0
+margin_left = 114.0
+margin_top = 4.0
+margin_right = 132.0
+margin_bottom = 22.0
 hint_tooltip = "tooltip_game_dir"
 texture_normal = ExtResource( 25 )
 
 [node name="BtnPlay" type="Button" parent="Main/Tabs/Game/CurrentInstall" groups=["disable_while_installing_game"]]
 margin_left = 259.0
-margin_top = 70.0
+margin_top = 64.0
 margin_right = 359.0
-margin_bottom = 102.0
+margin_bottom = 96.0
 rect_min_size = Vector2( 100, 32 )
 hint_tooltip = "tooltip_play"
 size_flags_horizontal = 4
@@ -277,9 +269,9 @@ icon = ExtResource( 3 )
 expand_icon = true
 
 [node name="Spacer" type="Control" parent="Main/Tabs/Game"]
-margin_top = 275.0
+margin_top = 262.0
 margin_right = 619.0
-margin_bottom = 275.0
+margin_bottom = 262.0
 
 [node name="ChangelogDialog" parent="Main/Tabs/Game" instance=ExtResource( 32 )]
 
@@ -288,30 +280,30 @@ visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
-margin_top = 38.5
+margin_top = 35.5
 margin_right = -7.5
 margin_bottom = -7.5
 script = ExtResource( 18 )
 
 [node name="HBox" type="HBoxContainer" parent="Main/Tabs/Mods"]
 margin_right = 619.0
-margin_bottom = 340.0
+margin_bottom = 330.0
 
 [node name="Installed" type="VBoxContainer" parent="Main/Tabs/Mods/HBox"]
-margin_right = 281.0
-margin_bottom = 340.0
+margin_right = 299.0
+margin_bottom = 330.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="Main/Tabs/Mods/HBox/Installed"]
-margin_right = 281.0
-margin_bottom = 29.0
+margin_right = 299.0
+margin_bottom = 26.0
 text = "lbl_installed_mods"
 align = 1
 
 [node name="InstalledList" type="ItemList" parent="Main/Tabs/Mods/HBox/Installed" groups=["disable_during_mod_operations"]]
-margin_top = 35.0
-margin_right = 281.0
-margin_bottom = 235.0
+margin_top = 32.0
+margin_right = 299.0
+margin_bottom = 232.0
 rect_min_size = Vector2( 0, 200 )
 size_flags_horizontal = 3
 items = [ "Item 0", null, false, "Item 1", null, false, "Item 2", null, false, "Item 3", null, false ]
@@ -321,45 +313,45 @@ same_column_width = true
 script = ExtResource( 17 )
 
 [node name="ShowStock" type="CheckBox" parent="Main/Tabs/Mods/HBox/Installed" groups=["disable_during_mod_operations"]]
-margin_left = 58.0
-margin_top = 241.0
+margin_left = 76.0
+margin_top = 238.0
 margin_right = 223.0
-margin_bottom = 270.0
+margin_bottom = 266.0
 hint_tooltip = "tooltip_stock_mods"
 size_flags_horizontal = 4
 text = "cbtn_stock_mods"
 
 [node name="BtnDelete" type="Button" parent="Main/Tabs/Mods/HBox/Installed" groups=["disable_during_mod_operations"]]
-margin_left = 66.0
-margin_top = 276.0
-margin_right = 214.0
-margin_bottom = 305.0
+margin_left = 83.0
+margin_top = 272.0
+margin_right = 215.0
+margin_bottom = 298.0
 hint_tooltip = "tooltip_delete_mods"
 size_flags_horizontal = 4
 disabled = true
 text = "btn_delete_mods"
 
 [node name="VSeparator" type="VSeparator" parent="Main/Tabs/Mods/HBox"]
-margin_left = 287.0
-margin_right = 295.0
-margin_bottom = 340.0
+margin_left = 305.0
+margin_right = 313.0
+margin_bottom = 330.0
 
 [node name="Available" type="VBoxContainer" parent="Main/Tabs/Mods/HBox"]
-margin_left = 301.0
+margin_left = 319.0
 margin_right = 619.0
-margin_bottom = 340.0
+margin_bottom = 330.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="Main/Tabs/Mods/HBox/Available"]
-margin_right = 318.0
-margin_bottom = 29.0
+margin_right = 300.0
+margin_bottom = 26.0
 text = "lbl_mod_repo"
 align = 1
 
 [node name="AvailableList" type="ItemList" parent="Main/Tabs/Mods/HBox/Available" groups=["disable_during_mod_operations"]]
-margin_top = 35.0
-margin_right = 318.0
-margin_bottom = 235.0
+margin_top = 32.0
+margin_right = 300.0
+margin_bottom = 232.0
 rect_min_size = Vector2( 0, 200 )
 size_flags_horizontal = 3
 items = [ "Item 0", null, false, "Item 1", null, false, "Item 2", null, false, "Item 3", null, false ]
@@ -370,58 +362,55 @@ script = ExtResource( 17 )
 
 [node name="ShowInstalled" type="CheckBox" parent="Main/Tabs/Mods/HBox/Available" groups=["disable_during_mod_operations"]]
 margin_left = 64.0
-margin_top = 241.0
-margin_right = 253.0
-margin_bottom = 270.0
+margin_top = 238.0
+margin_right = 235.0
+margin_bottom = 266.0
 hint_tooltip = "tooltip_installed_mods"
 size_flags_horizontal = 4
 text = "cbtn_installed_mods"
 
 [node name="VBox" type="HBoxContainer" parent="Main/Tabs/Mods/HBox/Available"]
-margin_top = 276.0
-margin_right = 318.0
-margin_bottom = 305.0
+margin_top = 272.0
+margin_right = 300.0
+margin_bottom = 298.0
 alignment = 1
 
 [node name="BtnAddSelectedMod" type="Button" parent="Main/Tabs/Mods/HBox/Available/VBox" groups=["disable_during_mod_operations"]]
-margin_right = 158.0
-margin_bottom = 29.0
+margin_left = 7.0
+margin_right = 148.0
+margin_bottom = 26.0
 hint_tooltip = "tooltip_add_sel_mods"
 size_flags_horizontal = 4
 text = "btn_add_sel_mods"
 
 [node name="BtnAddAllMods" type="Button" parent="Main/Tabs/Mods/HBox/Available/VBox" groups=["disable_during_mod_operations"]]
-margin_left = 164.0
-margin_right = 318.0
-margin_bottom = 29.0
+margin_left = 154.0
+margin_right = 292.0
+margin_bottom = 26.0
 hint_tooltip = "tooltip_add_all_mods"
 text = "btn_add_all_mods"
 
 [node name="BtnDownloadKenan" type="Button" parent="Main/Tabs/Mods/HBox/Available" groups=["disable_during_mod_operations"]]
 margin_left = 74.0
-margin_top = 311.0
-margin_right = 244.0
-margin_bottom = 340.0
+margin_top = 304.0
+margin_right = 226.0
+margin_bottom = 330.0
 hint_tooltip = "tooltip_get_kenan_pack"
 size_flags_horizontal = 4
 text = "btn_get_kenan_pack"
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Mods"]
-margin_top = 346.0
+margin_top = 336.0
 margin_right = 619.0
-margin_bottom = 354.0
+margin_bottom = 344.0
 
 [node name="ModInfo" type="RichTextLabel" parent="Main/Tabs/Mods"]
-margin_top = 360.0
+margin_top = 350.0
 margin_right = 619.0
-margin_bottom = 480.0
+margin_bottom = 470.0
 rect_min_size = Vector2( 0, 120 )
 focus_mode = 2
 custom_constants/line_separation = 4
-custom_fonts/bold_italics_font = ExtResource( 24 )
-custom_fonts/italics_font = ExtResource( 23 )
-custom_fonts/bold_font = ExtResource( 22 )
-custom_fonts/normal_font = ExtResource( 7 )
 bbcode_enabled = true
 bbcode_text = "Mod info will appear here."
 text = "Mod info will appear here."
@@ -447,7 +436,7 @@ visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
-margin_top = 38.5
+margin_top = 35.5
 margin_right = -7.5
 margin_bottom = -7.5
 size_flags_vertical = 3
@@ -455,23 +444,23 @@ script = ExtResource( 15 )
 
 [node name="HBox" type="HBoxContainer" parent="Main/Tabs/Soundpacks"]
 margin_right = 619.0
-margin_bottom = 305.0
+margin_bottom = 298.0
 
 [node name="Installed" type="VBoxContainer" parent="Main/Tabs/Soundpacks/HBox"]
 margin_right = 299.0
-margin_bottom = 305.0
+margin_bottom = 298.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="Main/Tabs/Soundpacks/HBox/Installed"]
 margin_right = 299.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 text = "lbl_installed_sound"
 align = 1
 
 [node name="InstalledList" type="ItemList" parent="Main/Tabs/Soundpacks/HBox/Installed" groups=["disable_during_soundpack_operations"]]
-margin_top = 35.0
+margin_top = 32.0
 margin_right = 299.0
-margin_bottom = 235.0
+margin_bottom = 232.0
 rect_min_size = Vector2( 0, 200 )
 size_flags_horizontal = 3
 items = [ "Item 0", null, false, "Item 1", null, false, "Item 2", null, false, "Item 3", null, false, "Item 4", null, false, "Item 5", null, false, "Item 6", null, false, "Item 7", null, false, "Item 8", null, false, "Item 9", null, false, "Item 10", null, false, "Item 11", null, false, "Item 12", null, false, "Item 13", null, false, "Item 14", null, false, "Item 15", null, false, "Item 16", null, false, "Item 17", null, false, "Item 18", null, false, "Item 19", null, false, "Item 20", null, false, "Item 21", null, false ]
@@ -479,19 +468,19 @@ same_column_width = true
 script = ExtResource( 17 )
 
 [node name="ShowStock" type="CheckBox" parent="Main/Tabs/Soundpacks/HBox/Installed" groups=["disable_during_soundpack_operations"]]
-margin_left = 64.0
-margin_top = 241.0
-margin_right = 234.0
-margin_bottom = 270.0
+margin_left = 73.0
+margin_top = 238.0
+margin_right = 225.0
+margin_bottom = 266.0
 hint_tooltip = "tooltip_stock_sound"
 size_flags_horizontal = 4
 text = "cbtn_stock_sound"
 
 [node name="BtnDelete" type="Button" parent="Main/Tabs/Soundpacks/HBox/Installed" groups=["disable_during_soundpack_operations"]]
-margin_left = 73.0
-margin_top = 276.0
-margin_right = 226.0
-margin_bottom = 305.0
+margin_left = 81.0
+margin_top = 272.0
+margin_right = 218.0
+margin_bottom = 298.0
 hint_tooltip = "tooltip_delete_sound"
 size_flags_horizontal = 4
 disabled = true
@@ -500,24 +489,24 @@ text = "btn_delete_sound"
 [node name="VSeparator" type="VSeparator" parent="Main/Tabs/Soundpacks/HBox"]
 margin_left = 305.0
 margin_right = 313.0
-margin_bottom = 305.0
+margin_bottom = 298.0
 
 [node name="Downloadable" type="VBoxContainer" parent="Main/Tabs/Soundpacks/HBox"]
 margin_left = 319.0
 margin_right = 619.0
-margin_bottom = 305.0
+margin_bottom = 298.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="Main/Tabs/Soundpacks/HBox/Downloadable"]
 margin_right = 300.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 text = "lbl_avail_sound"
 align = 1
 
 [node name="AvailableList" type="ItemList" parent="Main/Tabs/Soundpacks/HBox/Downloadable" groups=["disable_during_soundpack_operations"]]
-margin_top = 35.0
+margin_top = 32.0
 margin_right = 300.0
-margin_bottom = 235.0
+margin_bottom = 232.0
 rect_min_size = Vector2( 0, 200 )
 size_flags_horizontal = 3
 items = [ "Item 0", null, false, "Item 1", null, false, "Item 2", null, false, "Item 3", null, false ]
@@ -525,10 +514,10 @@ same_column_width = true
 script = ExtResource( 17 )
 
 [node name="BtnInstall" type="Button" parent="Main/Tabs/Soundpacks/HBox/Downloadable" groups=["disable_during_soundpack_operations"]]
-margin_left = 74.0
-margin_top = 241.0
-margin_right = 225.0
-margin_bottom = 270.0
+margin_left = 82.0
+margin_top = 238.0
+margin_right = 218.0
+margin_bottom = 264.0
 hint_tooltip = "tooltip_install_sound"
 size_flags_horizontal = 4
 disabled = true
@@ -566,256 +555,252 @@ visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
-margin_top = 38.5
+margin_top = 35.5
 margin_right = -7.5
 margin_bottom = -7.5
 script = ExtResource( 27 )
 
 [node name="FontSelection" type="HBoxContainer" parent="Main/Tabs/Fonts"]
-margin_right = 643.0
-margin_bottom = 432.0
+margin_right = 619.0
+margin_bottom = 412.0
 
 [node name="RightPane" type="VBoxContainer" parent="Main/Tabs/Fonts/FontSelection"]
-margin_right = 322.0
-margin_bottom = 432.0
+margin_right = 286.0
+margin_bottom = 412.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Fonts/FontSelection/RightPane"]
-margin_left = 102.0
-margin_right = 219.0
-margin_bottom = 29.0
+margin_left = 90.0
+margin_right = 196.0
+margin_bottom = 26.0
 size_flags_horizontal = 4
 text = "lbl_avail_fonts"
 align = 1
 
 [node name="FontsList" type="ItemList" parent="Main/Tabs/Fonts/FontSelection/RightPane"]
-margin_top = 35.0
-margin_right = 322.0
-margin_bottom = 285.0
+margin_top = 32.0
+margin_right = 286.0
+margin_bottom = 282.0
 rect_min_size = Vector2( 0, 250 )
 size_flags_stretch_ratio = 2.0
 items = [ "Item 0", null, false, "Item 1", null, false, "Item 2", null, false, "Item 3", null, false ]
 allow_reselect = true
 
 [node name="Buttons" type="VBoxContainer" parent="Main/Tabs/Fonts/FontSelection/RightPane"]
-margin_top = 312.0
-margin_right = 322.0
-margin_bottom = 411.0
+margin_top = 305.0
+margin_right = 286.0
+margin_bottom = 395.0
 size_flags_vertical = 6
 
 [node name="Grid" type="GridContainer" parent="Main/Tabs/Fonts/FontSelection/RightPane/Buttons"]
-margin_right = 322.0
-margin_bottom = 64.0
+margin_right = 286.0
+margin_bottom = 58.0
 size_flags_horizontal = 4
 columns = 2
 
 [node name="BtnSetFontUI" type="Button" parent="Main/Tabs/Fonts/FontSelection/RightPane/Buttons/Grid"]
-margin_right = 163.0
-margin_bottom = 29.0
+margin_right = 144.0
+margin_bottom = 26.0
 hint_tooltip = "tooltip_set_font_ui"
 text = "btn_set_font_ui"
 
 [node name="BtnSetFontMap" type="Button" parent="Main/Tabs/Fonts/FontSelection/RightPane/Buttons/Grid"]
-margin_left = 169.0
-margin_right = 322.0
-margin_bottom = 29.0
+margin_left = 150.0
+margin_right = 286.0
+margin_bottom = 26.0
 hint_tooltip = "tooltip_set_font_map"
 text = "btn_set_font_map"
 
 [node name="BtnSetFontOvermap" type="Button" parent="Main/Tabs/Fonts/FontSelection/RightPane/Buttons/Grid"]
-margin_top = 35.0
-margin_right = 163.0
-margin_bottom = 64.0
+margin_top = 32.0
+margin_right = 144.0
+margin_bottom = 58.0
 hint_tooltip = "tooltip_set_font_omap"
 text = "btn_set_font_omap"
 
 [node name="BtnSetFontAll" type="Button" parent="Main/Tabs/Fonts/FontSelection/RightPane/Buttons/Grid"]
-margin_left = 169.0
-margin_top = 35.0
-margin_right = 322.0
-margin_bottom = 64.0
+margin_left = 150.0
+margin_top = 32.0
+margin_right = 286.0
+margin_bottom = 58.0
 hint_tooltip = "tooltip_set_font_all"
 text = "btn_set_font_all"
 
 [node name="BtnResetFont" type="Button" parent="Main/Tabs/Fonts/FontSelection/RightPane/Buttons"]
-margin_left = 97.0
-margin_top = 70.0
-margin_right = 225.0
-margin_bottom = 99.0
+margin_left = 86.0
+margin_top = 64.0
+margin_right = 200.0
+margin_bottom = 90.0
 hint_tooltip = "tooltip_reset_font"
 size_flags_horizontal = 4
 text = "btn_reset_font"
 
 [node name="VSeparator" type="VSeparator" parent="Main/Tabs/Fonts/FontSelection"]
-margin_left = 328.0
-margin_right = 336.0
-margin_bottom = 432.0
+margin_left = 292.0
+margin_right = 300.0
+margin_bottom = 412.0
 
 [node name="LeftPane" type="VBoxContainer" parent="Main/Tabs/Fonts/FontSelection"]
-margin_left = 342.0
-margin_right = 643.0
-margin_bottom = 432.0
+margin_left = 306.0
+margin_right = 619.0
+margin_bottom = 412.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 3.0
 custom_constants/separation = 4
 
 [node name="Label" type="Label" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_left = 83.0
+margin_left = 96.0
 margin_right = 217.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 size_flags_horizontal = 4
 text = "lbl_font_preview"
 align = 1
 
 [node name="Preview" type="RichTextLabel" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 33.0
-margin_right = 301.0
-margin_bottom = 193.0
+margin_top = 30.0
+margin_right = 313.0
+margin_bottom = 190.0
 rect_min_size = Vector2( 0, 160 )
 custom_constants/line_separation = -2
 bbcode_enabled = true
 
 [node name="PreviewCyrillic" type="CheckBox" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_left = 52.0
-margin_top = 197.0
-margin_right = 248.0
-margin_bottom = 226.0
+margin_left = 67.0
+margin_top = 194.0
+margin_right = 246.0
+margin_bottom = 222.0
 hint_tooltip = "tooltip_preview_cyrillics"
 size_flags_horizontal = 4
 text = "cbtn_preview_cyrillics"
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 230.0
-margin_right = 301.0
-margin_bottom = 230.0
+margin_top = 226.0
+margin_right = 313.0
+margin_bottom = 226.0
 custom_constants/separation = 0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 234.0
-margin_right = 301.0
-margin_bottom = 234.0
+margin_top = 230.0
+margin_right = 313.0
+margin_bottom = 230.0
 custom_constants/separation = 0
 
 [node name="OtherSettings" type="HBoxContainer" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_left = 64.0
-margin_top = 238.0
-margin_right = 236.0
-margin_bottom = 267.0
+margin_left = 78.0
+margin_top = 234.0
+margin_right = 234.0
+margin_bottom = 260.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
 
 [node name="Label" type="Label" parent="Main/Tabs/Fonts/FontSelection/LeftPane/OtherSettings"]
-margin_right = 146.0
-margin_bottom = 29.0
+margin_right = 130.0
+margin_bottom = 26.0
 size_flags_horizontal = 4
 text = "lbl_other_settings"
 align = 1
 
 [node name="HelpIcon" parent="Main/Tabs/Fonts/FontSelection/LeftPane/OtherSettings" instance=ExtResource( 26 )]
-margin_left = 152.0
-margin_top = 4.0
-margin_right = 172.0
-margin_bottom = 24.0
+margin_left = 136.0
+margin_top = 3.0
+margin_right = 156.0
+margin_bottom = 23.0
 rect_min_size = Vector2( 20, 20 )
 hint_tooltip = "View detailed description of these settings."
 texture_normal = ExtResource( 30 )
 
 [node name="FontSizeUI" type="HBoxContainer" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 271.0
-margin_right = 301.0
-margin_bottom = 300.0
+margin_top = 264.0
+margin_right = 313.0
+margin_bottom = 290.0
 hint_tooltip = "tooltip_font_sz_ui"
 size_flags_vertical = 6
 
 [node name="Label" type="Label" parent="Main/Tabs/Fonts/FontSelection/LeftPane/FontSizeUI"]
-margin_right = 111.0
-margin_bottom = 29.0
+margin_right = 101.0
+margin_bottom = 26.0
 text = "lbl_font_sz_ui"
 
 [node name="sbFontSizeUI" type="SpinBox" parent="Main/Tabs/Fonts/FontSelection/LeftPane/FontSizeUI"]
-margin_left = 171.0
-margin_right = 301.0
-margin_bottom = 29.0
+margin_left = 183.0
+margin_right = 313.0
+margin_bottom = 26.0
 size_flags_horizontal = 10
 min_value = 8.0
 max_value = 64.0
 value = 8.0
 
 [node name="FontSizeMap" type="HBoxContainer" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 304.0
-margin_right = 301.0
-margin_bottom = 333.0
+margin_top = 294.0
+margin_right = 313.0
+margin_bottom = 320.0
 hint_tooltip = "tooltip_font_sz_map"
 size_flags_vertical = 6
 
 [node name="Label" type="Label" parent="Main/Tabs/Fonts/FontSelection/LeftPane/FontSizeMap"]
-margin_right = 131.0
-margin_bottom = 29.0
+margin_right = 118.0
+margin_bottom = 26.0
 hint_tooltip = "tooltip_font_sz_map"
 text = "lbl_font_sz_map"
 
 [node name="sbFontSizeMap" type="SpinBox" parent="Main/Tabs/Fonts/FontSelection/LeftPane/FontSizeMap"]
-margin_left = 171.0
-margin_right = 301.0
-margin_bottom = 29.0
+margin_left = 183.0
+margin_right = 313.0
+margin_bottom = 26.0
 size_flags_horizontal = 10
 min_value = 8.0
 max_value = 64.0
 value = 8.0
 
 [node name="FontSizeOvermap" type="HBoxContainer" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 337.0
-margin_right = 301.0
-margin_bottom = 366.0
+margin_top = 324.0
+margin_right = 313.0
+margin_bottom = 350.0
 hint_tooltip = "tooltip_font_sz_overmap"
 size_flags_vertical = 6
 
 [node name="Label" type="Label" parent="Main/Tabs/Fonts/FontSelection/LeftPane/FontSizeOvermap"]
-margin_right = 165.0
-margin_bottom = 29.0
+margin_right = 147.0
+margin_bottom = 26.0
 hint_tooltip = "tooltip_font_sz_overmap"
 text = "lbl_font_sz_overmap"
 
 [node name="sbFontSizeOM" type="SpinBox" parent="Main/Tabs/Fonts/FontSelection/LeftPane/FontSizeOvermap"]
-margin_left = 171.0
-margin_right = 301.0
-margin_bottom = 29.0
+margin_left = 183.0
+margin_right = 313.0
+margin_bottom = 26.0
 size_flags_horizontal = 10
 min_value = 8.0
 max_value = 64.0
 value = 8.0
 
 [node name="FontBlending" type="CheckButton" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 370.0
-margin_right = 301.0
-margin_bottom = 399.0
+margin_top = 354.0
+margin_right = 313.0
+margin_bottom = 382.0
 hint_tooltip = "tooltip_font_blending"
 text = "cbtn_font_blending"
 
 [node name="BtnSaveFontOptions" type="Button" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_left = 89.0
-margin_top = 403.0
-margin_right = 212.0
-margin_bottom = 432.0
+margin_left = 101.0
+margin_top = 386.0
+margin_right = 211.0
+margin_bottom = 412.0
 hint_tooltip = "tooltip_save_font"
 size_flags_horizontal = 4
 text = "btn_save_font"
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Fonts"]
-margin_top = 438.0
-margin_right = 643.0
-margin_bottom = 438.0
+margin_top = 418.0
+margin_right = 619.0
+margin_bottom = 418.0
 custom_constants/separation = 0
 
 [node name="FontConfigInfo" type="RichTextLabel" parent="Main/Tabs/Fonts"]
-margin_top = 444.0
-margin_right = 643.0
-margin_bottom = 532.0
-custom_fonts/bold_italics_font = ExtResource( 24 )
-custom_fonts/italics_font = ExtResource( 23 )
-custom_fonts/bold_font = ExtResource( 22 )
-custom_fonts/normal_font = ExtResource( 7 )
+margin_top = 424.0
+margin_right = 619.0
+margin_bottom = 500.0
 bbcode_enabled = true
 bbcode_text = "Existing font configuration will be shown here.
 ...
@@ -839,25 +824,25 @@ visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
-margin_top = 38.5
+margin_top = 35.5
 margin_right = -7.5
 margin_bottom = -7.5
 script = ExtResource( 33 )
 
 [node name="Available" type="VBoxContainer" parent="Main/Tabs/Backups"]
 margin_right = 619.0
-margin_bottom = 270.0
+margin_bottom = 264.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Backups/Available"]
 margin_right = 619.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 text = "lbl_save_backups"
 align = 1
 
 [node name="HBox" type="HBoxContainer" parent="Main/Tabs/Backups/Available"]
-margin_top = 35.0
+margin_top = 32.0
 margin_right = 619.0
-margin_bottom = 235.0
+margin_bottom = 232.0
 
 [node name="BackupsList" type="ItemList" parent="Main/Tabs/Backups/Available/HBox" groups=["disable_during_backup_operations"]]
 margin_right = 306.0
@@ -879,79 +864,79 @@ text = "Backup details will appear here."
 selection_enabled = true
 
 [node name="Buttons" type="HBoxContainer" parent="Main/Tabs/Backups/Available"]
-margin_top = 241.0
+margin_top = 238.0
 margin_right = 619.0
-margin_bottom = 270.0
+margin_bottom = 264.0
 alignment = 1
 
 [node name="BtnRestore" type="Button" parent="Main/Tabs/Backups/Available/Buttons" groups=["disable_during_backup_operations"]]
-margin_left = 51.0
-margin_right = 220.0
-margin_bottom = 29.0
+margin_left = 77.0
+margin_right = 227.0
+margin_bottom = 26.0
 text = "btn_restore_backup"
 
 [node name="BtnDelete" type="Button" parent="Main/Tabs/Backups/Available/Buttons" groups=["disable_during_backup_operations"]]
-margin_left = 226.0
-margin_right = 386.0
-margin_bottom = 29.0
+margin_left = 233.0
+margin_right = 377.0
+margin_bottom = 26.0
 text = "btn_delete_backup"
 
 [node name="BtnRefresh" type="Button" parent="Main/Tabs/Backups/Available/Buttons" groups=["disable_during_backup_operations"]]
-margin_left = 392.0
-margin_right = 568.0
-margin_bottom = 29.0
+margin_left = 383.0
+margin_right = 541.0
+margin_bottom = 26.0
 text = "btn_refresh_backups"
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Backups"]
-margin_top = 276.0
+margin_top = 270.0
 margin_right = 619.0
-margin_bottom = 284.0
+margin_bottom = 278.0
 
 [node name="Current" type="VBoxContainer" parent="Main/Tabs/Backups"]
-margin_top = 290.0
+margin_top = 284.0
 margin_right = 619.0
-margin_bottom = 360.0
+margin_bottom = 348.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Backups/Current"]
 margin_right = 619.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 text = "lbl_manual_backup"
 align = 1
 
 [node name="HBox" type="HBoxContainer" parent="Main/Tabs/Backups/Current"]
-margin_top = 35.0
+margin_top = 32.0
 margin_right = 619.0
-margin_bottom = 64.0
+margin_bottom = 58.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Backups/Current/HBox"]
-margin_right = 142.0
-margin_bottom = 29.0
+margin_right = 128.0
+margin_bottom = 26.0
 text = "lbl_backup_name"
 
 [node name="EditName" type="LineEdit" parent="Main/Tabs/Backups/Current/HBox"]
-margin_left = 148.0
-margin_right = 452.0
-margin_bottom = 29.0
+margin_left = 134.0
+margin_right = 469.0
+margin_bottom = 26.0
 size_flags_horizontal = 3
 placeholder_text = "Enter name for new backup"
 
 [node name="BtnCreate" type="Button" parent="Main/Tabs/Backups/Current/HBox" groups=["disable_during_backup_operations"]]
-margin_left = 458.0
+margin_left = 475.0
 margin_right = 619.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 size_flags_horizontal = 4
 text = "btn_create_backup"
 
 [node name="Spacer" type="Control" parent="Main/Tabs/Backups/Current"]
-margin_top = 70.0
+margin_top = 64.0
 margin_right = 619.0
-margin_bottom = 70.0
+margin_bottom = 64.0
 
 [node name="Settings" type="VBoxContainer" parent="Main/Tabs"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
-margin_top = 38.5
+margin_top = 35.5
 margin_right = -7.5
 margin_bottom = -7.5
 custom_constants/separation = 2
@@ -959,18 +944,18 @@ script = ExtResource( 8 )
 
 [node name="LauncherLanguage" type="HBoxContainer" parent="Main/Tabs/Settings"]
 margin_right = 619.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 hint_tooltip = "tooltip_num_releases_to_request"
 
 [node name="Label" type="Label" parent="Main/Tabs/Settings/LauncherLanguage"]
-margin_right = 180.0
-margin_bottom = 29.0
+margin_right = 163.0
+margin_bottom = 26.0
 text = "lbl_launcher_language"
 
 [node name="obtnLanguage" type="OptionButton" parent="Main/Tabs/Settings/LauncherLanguage"]
 margin_left = 439.0
 margin_right = 619.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 rect_min_size = Vector2( 180, 0 )
 size_flags_horizontal = 10
 text = "English"
@@ -980,89 +965,89 @@ items = [ "English", ExtResource( 35 ), false, 0, null, "Русский", ExtRes
 selected = 0
 
 [node name="ShowGameDesc" type="CheckButton" parent="Main/Tabs/Settings"]
-margin_top = 31.0
+margin_top = 28.0
 margin_right = 619.0
-margin_bottom = 60.0
+margin_bottom = 56.0
 hint_tooltip = "tooltip_show_game_desc"
 text = "cbtn_show_game_desc"
 
 [node name="PrintTips" type="CheckButton" parent="Main/Tabs/Settings"]
-margin_top = 62.0
+margin_top = 58.0
 margin_right = 619.0
-margin_bottom = 91.0
+margin_bottom = 86.0
 hint_tooltip = "tooltip_print_tips"
 text = "cbtn_print_tips"
 
 [node name="UpdateToSame" type="CheckButton" parent="Main/Tabs/Settings"]
-margin_top = 93.0
+margin_top = 88.0
 margin_right = 619.0
-margin_bottom = 122.0
+margin_bottom = 116.0
 hint_tooltip = "tooltip_updating_to_same_build"
 text = "cbtn_updating_to_same_build"
 
 [node name="ShortenNames" type="CheckButton" parent="Main/Tabs/Settings"]
-margin_top = 124.0
+margin_top = 118.0
 margin_right = 619.0
-margin_bottom = 153.0
+margin_bottom = 146.0
 hint_tooltip = "tooltip_shorten_release_names"
 text = "cbtn_shorten_release_names"
 
 [node name="ShowObsoleteMods" type="CheckButton" parent="Main/Tabs/Settings"]
-margin_top = 155.0
+margin_top = 148.0
 margin_right = 619.0
-margin_bottom = 184.0
+margin_bottom = 176.0
 hint_tooltip = "tooltip_show_obsolete_mods"
 text = "cbtn_show_obsolete_mods"
 
 [node name="InstallArchivedMods" type="CheckButton" parent="Main/Tabs/Settings"]
-margin_top = 186.0
+margin_top = 178.0
 margin_right = 619.0
-margin_bottom = 215.0
+margin_bottom = 206.0
 hint_tooltip = "tooltip_install_archived_mods"
 text = "cbtn_install_archived_mods"
 
 [node name="ShowDebug" type="CheckButton" parent="Main/Tabs/Settings"]
-margin_top = 217.0
+margin_top = 208.0
 margin_right = 619.0
-margin_bottom = 246.0
+margin_bottom = 236.0
 hint_tooltip = "tooltip_debug_mode"
 text = "cbtn_debug_mode"
 
 [node name="NumReleases" type="HBoxContainer" parent="Main/Tabs/Settings"]
-margin_top = 248.0
+margin_top = 238.0
 margin_right = 619.0
-margin_bottom = 277.0
+margin_bottom = 264.0
 hint_tooltip = "tooltip_num_releases_to_request"
 
 [node name="Label" type="Label" parent="Main/Tabs/Settings/NumReleases"]
-margin_right = 231.0
-margin_bottom = 29.0
+margin_right = 205.0
+margin_bottom = 26.0
 text = "lbl_num_releases_to_request"
 
 [node name="sbNumReleases" type="SpinBox" parent="Main/Tabs/Settings/NumReleases"]
 margin_left = 489.0
 margin_right = 619.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 size_flags_horizontal = 10
 min_value = 1.0
 value = 30.0
 rounded = true
 
 [node name="NumPrs" type="HBoxContainer" parent="Main/Tabs/Settings"]
-margin_top = 279.0
+margin_top = 266.0
 margin_right = 619.0
-margin_bottom = 308.0
+margin_bottom = 292.0
 hint_tooltip = "tooltip_num_prs_to_request"
 
 [node name="Label" type="Label" parent="Main/Tabs/Settings/NumPrs"]
-margin_right = 193.0
-margin_bottom = 29.0
+margin_right = 171.0
+margin_bottom = 26.0
 text = "lbl_num_prs_to_request"
 
 [node name="sbNumPRs" type="SpinBox" parent="Main/Tabs/Settings/NumPrs"]
 margin_left = 489.0
 margin_right = 619.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 size_flags_horizontal = 10
 min_value = 10.0
 step = 10.0
@@ -1070,23 +1055,24 @@ value = 100.0
 rounded = true
 
 [node name="ScaleOverride" type="HBoxContainer" parent="Main/Tabs/Settings"]
-margin_top = 310.0
+margin_top = 294.0
 margin_right = 619.0
-margin_bottom = 339.0
+margin_bottom = 322.0
 hint_tooltip = "tooltip_ui_scale_override"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Label" type="Label" parent="Main/Tabs/Settings/ScaleOverride"]
-margin_right = 167.0
-margin_bottom = 29.0
+margin_top = 1.0
+margin_right = 150.0
+margin_bottom = 27.0
 text = "lbl_ui_scale_override"
 
 [node name="cbScaleOverrideEnable" type="CheckBox" parent="Main/Tabs/Settings/ScaleOverride"]
-margin_left = 312.0
+margin_left = 327.0
 margin_right = 483.0
-margin_bottom = 29.0
+margin_bottom = 28.0
 size_flags_horizontal = 10
 size_flags_stretch_ratio = 20.0
 text = "cbtn_enable_scale"
@@ -1094,7 +1080,7 @@ text = "cbtn_enable_scale"
 [node name="sbScaleOverride" type="SpinBox" parent="Main/Tabs/Settings/ScaleOverride"]
 margin_left = 489.0
 margin_right = 619.0
-margin_bottom = 29.0
+margin_bottom = 28.0
 size_flags_horizontal = 10
 min_value = 75.0
 max_value = 300.0
@@ -1104,92 +1090,92 @@ editable = false
 suffix = "%"
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Settings"]
-margin_top = 341.0
+margin_top = 324.0
 margin_right = 619.0
-margin_bottom = 349.0
+margin_bottom = 332.0
 
 [node name="Migration" type="VBoxContainer" parent="Main/Tabs/Settings"]
-margin_top = 351.0
+margin_top = 334.0
 margin_right = 619.0
-margin_bottom = 463.0
+margin_bottom = 440.0
 hint_tooltip = "tooltip_data_to_migrate"
 custom_constants/separation = 4
 
 [node name="Label" type="Label" parent="Main/Tabs/Settings/Migration"]
 margin_right = 619.0
-margin_bottom = 29.0
+margin_bottom = 26.0
 text = "lbl_data_to_migrate"
 
 [node name="Grid" type="GridContainer" parent="Main/Tabs/Settings/Migration"]
-margin_top = 33.0
+margin_top = 30.0
 margin_right = 619.0
-margin_bottom = 112.0
+margin_bottom = 106.0
 custom_constants/vseparation = -4
 columns = 3
 
 [node name="Savegames" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_right = 161.0
-margin_bottom = 29.0
+margin_right = 145.0
+margin_bottom = 28.0
 pressed = true
 text = "cbox_savegames"
 
 [node name="Fonts" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_left = 167.0
-margin_right = 335.0
-margin_bottom = 29.0
+margin_left = 151.0
+margin_right = 302.0
+margin_bottom = 28.0
 pressed = true
 text = "cbox_fonts"
 
 [node name="Templates" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_left = 341.0
-margin_right = 494.0
-margin_bottom = 29.0
+margin_left = 308.0
+margin_right = 446.0
+margin_bottom = 28.0
 pressed = true
 text = "cbox_templates"
 
 [node name="Settings" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_top = 25.0
-margin_right = 161.0
-margin_bottom = 54.0
+margin_top = 24.0
+margin_right = 145.0
+margin_bottom = 52.0
 pressed = true
 text = "cbox_settings"
 
 [node name="Tilesets" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_left = 167.0
-margin_top = 25.0
-margin_right = 335.0
-margin_bottom = 54.0
+margin_left = 151.0
+margin_top = 24.0
+margin_right = 302.0
+margin_bottom = 52.0
 pressed = true
 text = "cbox_tilesets"
 
 [node name="Memorial" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_left = 341.0
-margin_top = 25.0
-margin_right = 494.0
-margin_bottom = 54.0
+margin_left = 308.0
+margin_top = 24.0
+margin_right = 446.0
+margin_bottom = 52.0
 pressed = true
 text = "cbox_memorial"
 
 [node name="Mods" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_top = 50.0
-margin_right = 161.0
-margin_bottom = 79.0
+margin_top = 48.0
+margin_right = 145.0
+margin_bottom = 76.0
 pressed = true
 text = "cbox_mods"
 
 [node name="Soundpacks" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_left = 167.0
-margin_top = 50.0
-margin_right = 335.0
-margin_bottom = 79.0
+margin_left = 151.0
+margin_top = 48.0
+margin_right = 302.0
+margin_bottom = 76.0
 pressed = true
 text = "cbos_soundpacks"
 
 [node name="Graveyard" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_left = 341.0
-margin_top = 50.0
-margin_right = 494.0
-margin_bottom = 79.0
+margin_left = 308.0
+margin_top = 48.0
+margin_right = 446.0
+margin_bottom = 76.0
 pressed = true
 text = "cbox_graveyard"
 
@@ -1198,92 +1184,88 @@ visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
-margin_top = 38.5
+margin_top = 35.5
 margin_right = -7.5
 margin_bottom = -7.5
 script = ExtResource( 14 )
 
 [node name="Label" type="Label" parent="Main/Tabs/Debug"]
-margin_right = 769.0
-margin_bottom = 50.0
+margin_right = 619.0
+margin_bottom = 44.0
 text = "This tab contains functions helpful in debugging parts of the launcher during development. Useless for anything else."
 align = 1
 autowrap = true
 
 [node name="Button" type="Button" parent="Main/Tabs/Debug"]
-margin_left = 273.0
-margin_top = 56.0
-margin_right = 495.0
-margin_bottom = 85.0
+margin_left = 210.0
+margin_top = 50.0
+margin_right = 408.0
+margin_bottom = 76.0
 size_flags_horizontal = 6
 text = "Test mod directory parsing"
 
 [node name="Button2" type="Button" parent="Main/Tabs/Debug"]
-margin_left = 267.0
-margin_top = 91.0
-margin_right = 502.0
-margin_bottom = 120.0
+margin_left = 204.0
+margin_top = 82.0
+margin_right = 414.0
+margin_bottom = 108.0
 size_flags_horizontal = 6
 text = "Test sound directory parsing"
 
 [node name="Button3" type="Button" parent="Main/Tabs/Debug"]
-margin_left = 202.0
-margin_top = 126.0
-margin_right = 567.0
-margin_bottom = 155.0
+margin_left = 146.0
+margin_top = 114.0
+margin_right = 472.0
+margin_bottom = 140.0
 size_flags_horizontal = 6
 text = "Test passing of arguments to shell commands"
 
 [node name="Button4" type="Button" parent="Main/Tabs/Debug"]
-margin_left = 228.0
-margin_top = 161.0
-margin_right = 540.0
-margin_bottom = 190.0
+margin_left = 169.0
+margin_top = 146.0
+margin_right = 449.0
+margin_bottom = 172.0
 size_flags_horizontal = 6
 text = "Test different types of status messages"
 
 [node name="Button5" type="Button" parent="Main/Tabs/Debug"]
-margin_left = 262.0
-margin_top = 196.0
-margin_right = 507.0
-margin_bottom = 225.0
+margin_left = 199.0
+margin_top = 178.0
+margin_right = 419.0
+margin_bottom = 204.0
 size_flags_horizontal = 4
 text = "Test recursive directory listing"
 
 [node name="Button6" type="Button" parent="Main/Tabs/Debug"]
-margin_left = 264.0
-margin_top = 231.0
-margin_right = 505.0
-margin_bottom = 260.0
+margin_left = 201.0
+margin_top = 210.0
+margin_right = 417.0
+margin_bottom = 236.0
 size_flags_horizontal = 4
 text = "Print a random Tip of the Day"
 
 [node name="Button7" type="Button" parent="Main/Tabs/Debug"]
-margin_left = 245.0
-margin_top = 266.0
-margin_right = 523.0
-margin_bottom = 295.0
+margin_left = 185.0
+margin_top = 242.0
+margin_right = 433.0
+margin_bottom = 268.0
 size_flags_horizontal = 4
 text = "Test path resolution in PathHelper"
 
 [node name="Button8" type="Button" parent="Main/Tabs/Debug"]
-margin_left = 283.0
-margin_top = 301.0
-margin_right = 486.0
-margin_bottom = 330.0
+margin_left = 218.0
+margin_top = 274.0
+margin_right = 400.0
+margin_bottom = 300.0
 size_flags_horizontal = 4
 text = "Test translation retrieval"
 
 [node name="Log" type="RichTextLabel" parent="Main"]
-margin_top = 604.0
+margin_top = 569.0
 margin_right = 634.0
 margin_bottom = 784.0
 focus_mode = 2
 size_flags_vertical = 3
-custom_fonts/bold_italics_font = ExtResource( 24 )
-custom_fonts/italics_font = ExtResource( 23 )
-custom_fonts/bold_font = ExtResource( 22 )
-custom_fonts/normal_font = ExtResource( 7 )
 bbcode_enabled = true
 scroll_following = true
 selection_enabled = true

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -53,27 +53,27 @@ __meta__ = {
 [node name="Main" type="VBoxContainer" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 8.0
-margin_top = 6.32009
-margin_right = -8.0
-margin_bottom = -9.67993
+margin_left = 4.0
+margin_top = 4.0
+margin_right = -4.0
+margin_bottom = -4.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="GameChoice" type="HBoxContainer" parent="Main"]
-margin_right = 634.0
-margin_bottom = 26.0
+margin_right = 592.0
+margin_bottom = 24.0
 
 [node name="Label" type="Label" parent="Main/GameChoice"]
-margin_right = 72.0
-margin_bottom = 26.0
+margin_right = 65.0
+margin_bottom = 24.0
 text = "lbl_game"
 
 [node name="GamesList" type="OptionButton" parent="Main/GameChoice" groups=["disable_during_mod_operations", "disable_during_soundpack_operations", "disable_while_fetching_releases", "disable_while_installing_game"]]
-margin_left = 78.0
-margin_right = 634.0
-margin_bottom = 26.0
+margin_left = 71.0
+margin_right = 592.0
+margin_bottom = 24.0
 hint_tooltip = "tooltip_game"
 size_flags_horizontal = 3
 text = "Cataclysm: Dark Days Ahead"
@@ -81,19 +81,19 @@ items = [ "Cataclysm: Dark Days Ahead", null, false, 0, null, "Cataclysm: Bright
 selected = 0
 
 [node name="GameInfo" type="HBoxContainer" parent="Main"]
-margin_top = 32.0
-margin_right = 634.0
-margin_bottom = 76.0
+margin_top = 28.0
+margin_right = 592.0
+margin_bottom = 96.0
 custom_constants/separation = 8
 
 [node name="Spacer" type="Control" parent="Main/GameInfo"]
-margin_bottom = 44.0
+margin_bottom = 68.0
 
 [node name="Icon" type="TextureRect" parent="Main/GameInfo"]
 margin_left = 8.0
-margin_top = 6.0
+margin_top = 18.0
 margin_right = 40.0
-margin_bottom = 38.0
+margin_bottom = 50.0
 rect_min_size = Vector2( 32, 32 )
 size_flags_horizontal = 4
 size_flags_vertical = 4
@@ -103,24 +103,24 @@ stretch_mode = 6
 
 [node name="Description" type="RichTextLabel" parent="Main/GameInfo"]
 margin_left = 48.0
-margin_right = 634.0
-margin_bottom = 44.0
+margin_right = 592.0
+margin_bottom = 68.0
 size_flags_horizontal = 3
 size_flags_vertical = 4
 bbcode_enabled = true
-bbcode_text = "[b]Game Title[/b] is a game in which... and other stuff about the game. This is just a placeholder. At runtime, a proper description will be loaded here."
-text = "Game Title is a game in which... and other stuff about the game. This is just a placeholder. At runtime, a proper description will be loaded here."
+bbcode_text = "[b]Game Title[/b] is a game in which... This is a placeholder text to gauge how much space will be taken for the game description that will be loaded into this label at runtime. The descriptions are around 4 lines each at this width, so the placeholder text mush have a similar length to perform its function. This length is about right."
+text = "Game Title is a game in which... This is a placeholder text to gauge how much space will be taken for the game description that will be loaded into this label at runtime. The descriptions are around 4 lines each at this width, so the placeholder text mush have a similar length to perform its function. This length is about right."
 fit_content_height = true
 
 [node name="Spacer" type="Control" parent="Main"]
-margin_top = 82.0
-margin_right = 634.0
-margin_bottom = 82.0
+margin_top = 100.0
+margin_right = 592.0
+margin_bottom = 100.0
 
 [node name="Tabs" type="TabContainer" parent="Main" groups=["disable_during_backup_operations", "disable_during_mod_operations", "disable_during_soundpack_operations", "disable_while_fetching_releases", "disable_while_installing_game"]]
-margin_top = 88.0
-margin_right = 634.0
-margin_bottom = 383.0
+margin_top = 104.0
+margin_right = 592.0
+margin_bottom = 373.0
 tab_align = 0
 script = ExtResource( 16 )
 
@@ -128,27 +128,27 @@ script = ExtResource( 16 )
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
-margin_top = 35.5
+margin_top = 33.5
 margin_right = -7.5
 margin_bottom = -7.5
 
 [node name="Channel" type="VBoxContainer" parent="Main/Tabs/Game"]
-margin_right = 619.0
-margin_bottom = 60.0
+margin_right = 577.0
+margin_bottom = 56.0
 
 [node name="HBox" type="HBoxContainer" parent="Main/Tabs/Game/Channel"]
-margin_right = 619.0
-margin_bottom = 26.0
+margin_right = 577.0
+margin_bottom = 24.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Game/Channel/HBox"]
-margin_right = 89.0
-margin_bottom = 26.0
+margin_right = 79.0
+margin_bottom = 24.0
 text = "lbl_channel"
 
 [node name="ChangelogLink" type="RichTextLabel" parent="Main/Tabs/Game/Channel/HBox"]
-margin_left = 95.0
-margin_right = 619.0
-margin_bottom = 26.0
+margin_left = 85.0
+margin_right = 577.0
+margin_bottom = 24.0
 rect_min_size = Vector2( 300, 0 )
 hint_tooltip = "tooltip_changelog"
 size_flags_horizontal = 3
@@ -158,20 +158,20 @@ text = "lbl_changelog"
 scroll_active = false
 
 [node name="Group" type="HBoxContainer" parent="Main/Tabs/Game/Channel"]
-margin_top = 32.0
-margin_right = 619.0
-margin_bottom = 60.0
+margin_top = 28.0
+margin_right = 577.0
+margin_bottom = 56.0
 
 [node name="RBtnStable" type="CheckBox" parent="Main/Tabs/Game/Channel/Group" groups=["disable_while_fetching_releases", "disable_while_installing_game"]]
-margin_right = 110.0
+margin_right = 102.0
 margin_bottom = 28.0
 hint_tooltip = "tooltip_stable"
 group = SubResource( 1 )
 text = "rbtn_stable"
 
 [node name="RBtnExperimental" type="CheckBox" parent="Main/Tabs/Game/Channel/Group" groups=["disable_while_fetching_releases", "disable_while_installing_game"]]
-margin_left = 116.0
-margin_right = 274.0
+margin_left = 108.0
+margin_right = 253.0
 margin_bottom = 28.0
 hint_tooltip = "tooltip_experimental"
 pressed = true
@@ -179,35 +179,35 @@ group = SubResource( 1 )
 text = "rbtn_experimental"
 
 [node name="Builds" type="HBoxContainer" parent="Main/Tabs/Game"]
-margin_top = 66.0
-margin_right = 619.0
-margin_bottom = 92.0
+margin_top = 60.0
+margin_right = 577.0
+margin_bottom = 84.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Game/Builds"]
-margin_right = 77.0
-margin_bottom = 26.0
+margin_right = 68.0
+margin_bottom = 24.0
 text = "lbl_builds"
 
 [node name="BuildsList" type="OptionButton" parent="Main/Tabs/Game/Builds" groups=["disable_while_fetching_releases", "disable_while_installing_game"]]
-margin_left = 83.0
-margin_right = 517.0
-margin_bottom = 26.0
+margin_left = 74.0
+margin_right = 490.0
+margin_bottom = 24.0
 hint_tooltip = "tooltip_builds"
 size_flags_horizontal = 3
 clip_text = true
 
 [node name="BtnRefresh" type="Button" parent="Main/Tabs/Game/Builds" groups=["disable_while_fetching_releases", "disable_while_installing_game"]]
-margin_left = 523.0
-margin_right = 619.0
-margin_bottom = 26.0
+margin_left = 496.0
+margin_right = 577.0
+margin_bottom = 24.0
 hint_tooltip = "tooltip_refresh"
 text = "btn_refresh"
 
 [node name="BtnInstall" type="Button" parent="Main/Tabs/Game" groups=["disable_while_fetching_releases", "disable_while_installing_game"]]
-margin_left = 189.0
-margin_top = 98.0
-margin_right = 429.0
-margin_bottom = 130.0
+margin_left = 168.0
+margin_top = 88.0
+margin_right = 408.0
+margin_bottom = 120.0
 rect_min_size = Vector2( 240, 32 )
 hint_tooltip = "tooltip_install"
 size_flags_horizontal = 4
@@ -216,48 +216,48 @@ icon = ExtResource( 2 )
 expand_icon = true
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Game"]
-margin_top = 136.0
-margin_right = 619.0
-margin_bottom = 144.0
+margin_top = 124.0
+margin_right = 577.0
+margin_bottom = 132.0
 
 [node name="CurrentInstall" type="VBoxContainer" parent="Main/Tabs/Game"]
-margin_top = 150.0
-margin_right = 619.0
-margin_bottom = 246.0
+margin_top = 136.0
+margin_right = 577.0
+margin_bottom = 224.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Game/CurrentInstall"]
-margin_right = 619.0
-margin_bottom = 26.0
+margin_right = 577.0
+margin_bottom = 24.0
 text = "lbl_currently_installed"
 align = 1
 
 [node name="Build" type="HBoxContainer" parent="Main/Tabs/Game/CurrentInstall"]
-margin_left = 243.0
-margin_top = 32.0
-margin_right = 375.0
-margin_bottom = 58.0
+margin_left = 228.0
+margin_top = 28.0
+margin_right = 349.0
+margin_bottom = 52.0
 size_flags_horizontal = 4
 custom_constants/separation = 4
 
 [node name="Name" type="Label" parent="Main/Tabs/Game/CurrentInstall/Build"]
-margin_right = 110.0
-margin_bottom = 26.0
+margin_right = 99.0
+margin_bottom = 24.0
 text = "lbl_build_none"
 align = 1
 
 [node name="GameDir" parent="Main/Tabs/Game/CurrentInstall/Build" instance=ExtResource( 26 )]
-margin_left = 114.0
-margin_top = 4.0
-margin_right = 132.0
-margin_bottom = 22.0
+margin_left = 103.0
+margin_top = 3.0
+margin_right = 121.0
+margin_bottom = 21.0
 hint_tooltip = "tooltip_game_dir"
 texture_normal = ExtResource( 25 )
 
 [node name="BtnPlay" type="Button" parent="Main/Tabs/Game/CurrentInstall" groups=["disable_while_installing_game"]]
-margin_left = 259.0
-margin_top = 64.0
-margin_right = 359.0
-margin_bottom = 96.0
+margin_left = 238.0
+margin_top = 56.0
+margin_right = 338.0
+margin_bottom = 88.0
 rect_min_size = Vector2( 100, 32 )
 hint_tooltip = "tooltip_play"
 size_flags_horizontal = 4
@@ -266,9 +266,9 @@ icon = ExtResource( 3 )
 expand_icon = true
 
 [node name="Spacer" type="Control" parent="Main/Tabs/Game"]
-margin_top = 252.0
-margin_right = 619.0
-margin_bottom = 252.0
+margin_top = 228.0
+margin_right = 577.0
+margin_bottom = 228.0
 
 [node name="ChangelogDialog" parent="Main/Tabs/Game" instance=ExtResource( 32 )]
 
@@ -277,31 +277,31 @@ visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
-margin_top = 35.5
+margin_top = 33.5
 margin_right = -7.5
 margin_bottom = -7.5
 script = ExtResource( 18 )
 
 [node name="HBox" type="HBoxContainer" parent="Main/Tabs/Mods"]
-margin_right = 619.0
-margin_bottom = 330.0
+margin_right = 577.0
+margin_bottom = 296.0
 
 [node name="Installed" type="VBoxContainer" parent="Main/Tabs/Mods/HBox"]
-margin_right = 299.0
-margin_bottom = 330.0
+margin_right = 278.0
+margin_bottom = 296.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="Main/Tabs/Mods/HBox/Installed"]
-margin_right = 299.0
-margin_bottom = 26.0
+margin_right = 278.0
+margin_bottom = 24.0
 text = "lbl_installed_mods"
 align = 1
 
 [node name="InstalledList" type="ItemList" parent="Main/Tabs/Mods/HBox/Installed" groups=["disable_during_mod_operations"]]
-margin_top = 32.0
-margin_right = 299.0
-margin_bottom = 232.0
-rect_min_size = Vector2( 0, 200 )
+margin_top = 28.0
+margin_right = 278.0
+margin_bottom = 208.0
+rect_min_size = Vector2( 0, 180 )
 size_flags_horizontal = 3
 items = [ "Item 0", null, false, "Item 1", null, false, "Item 2", null, false, "Item 3", null, false ]
 select_mode = 1
@@ -310,46 +310,46 @@ same_column_width = true
 script = ExtResource( 17 )
 
 [node name="ShowStock" type="CheckBox" parent="Main/Tabs/Mods/HBox/Installed" groups=["disable_during_mod_operations"]]
-margin_left = 76.0
-margin_top = 238.0
-margin_right = 223.0
-margin_bottom = 266.0
+margin_left = 69.0
+margin_top = 212.0
+margin_right = 208.0
+margin_bottom = 240.0
 hint_tooltip = "tooltip_stock_mods"
 size_flags_horizontal = 4
 text = "cbtn_stock_mods"
 
 [node name="BtnDelete" type="Button" parent="Main/Tabs/Mods/HBox/Installed" groups=["disable_during_mod_operations"]]
-margin_left = 83.0
-margin_top = 272.0
-margin_right = 215.0
-margin_bottom = 298.0
+margin_left = 81.0
+margin_top = 244.0
+margin_right = 197.0
+margin_bottom = 268.0
 hint_tooltip = "tooltip_delete_mods"
 size_flags_horizontal = 4
 disabled = true
 text = "btn_delete_mods"
 
 [node name="VSeparator" type="VSeparator" parent="Main/Tabs/Mods/HBox"]
-margin_left = 305.0
-margin_right = 313.0
-margin_bottom = 330.0
+margin_left = 284.0
+margin_right = 292.0
+margin_bottom = 296.0
 
 [node name="Available" type="VBoxContainer" parent="Main/Tabs/Mods/HBox"]
-margin_left = 319.0
-margin_right = 619.0
-margin_bottom = 330.0
+margin_left = 298.0
+margin_right = 577.0
+margin_bottom = 296.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="Main/Tabs/Mods/HBox/Available"]
-margin_right = 300.0
-margin_bottom = 26.0
+margin_right = 279.0
+margin_bottom = 24.0
 text = "lbl_mod_repo"
 align = 1
 
 [node name="AvailableList" type="ItemList" parent="Main/Tabs/Mods/HBox/Available" groups=["disable_during_mod_operations"]]
-margin_top = 32.0
-margin_right = 300.0
-margin_bottom = 232.0
-rect_min_size = Vector2( 0, 200 )
+margin_top = 28.0
+margin_right = 279.0
+margin_bottom = 208.0
+rect_min_size = Vector2( 0, 180 )
 size_flags_horizontal = 3
 items = [ "Item 0", null, false, "Item 1", null, false, "Item 2", null, false, "Item 3", null, false ]
 select_mode = 1
@@ -358,54 +358,54 @@ same_column_width = true
 script = ExtResource( 17 )
 
 [node name="ShowInstalled" type="CheckBox" parent="Main/Tabs/Mods/HBox/Available" groups=["disable_during_mod_operations"]]
-margin_left = 64.0
-margin_top = 238.0
-margin_right = 235.0
-margin_bottom = 266.0
+margin_left = 61.0
+margin_top = 212.0
+margin_right = 218.0
+margin_bottom = 240.0
 hint_tooltip = "tooltip_installed_mods"
 size_flags_horizontal = 4
 text = "cbtn_installed_mods"
 
 [node name="VBox" type="HBoxContainer" parent="Main/Tabs/Mods/HBox/Available"]
-margin_top = 272.0
-margin_right = 300.0
-margin_bottom = 298.0
+margin_top = 244.0
+margin_right = 279.0
+margin_bottom = 268.0
 alignment = 1
 
 [node name="BtnAddSelectedMod" type="Button" parent="Main/Tabs/Mods/HBox/Available/VBox" groups=["disable_during_mod_operations"]]
-margin_left = 7.0
-margin_right = 148.0
-margin_bottom = 26.0
+margin_left = 14.0
+margin_right = 138.0
+margin_bottom = 24.0
 hint_tooltip = "tooltip_add_sel_mods"
 size_flags_horizontal = 4
 text = "btn_add_sel_mods"
 
 [node name="BtnAddAllMods" type="Button" parent="Main/Tabs/Mods/HBox/Available/VBox" groups=["disable_during_mod_operations"]]
-margin_left = 154.0
-margin_right = 292.0
-margin_bottom = 26.0
+margin_left = 144.0
+margin_right = 265.0
+margin_bottom = 24.0
 hint_tooltip = "tooltip_add_all_mods"
 text = "btn_add_all_mods"
 
 [node name="BtnDownloadKenan" type="Button" parent="Main/Tabs/Mods/HBox/Available" groups=["disable_during_mod_operations"]]
-margin_left = 74.0
-margin_top = 304.0
-margin_right = 226.0
-margin_bottom = 330.0
+margin_left = 72.0
+margin_top = 272.0
+margin_right = 207.0
+margin_bottom = 296.0
 hint_tooltip = "tooltip_get_kenan_pack"
 size_flags_horizontal = 4
 text = "btn_get_kenan_pack"
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Mods"]
-margin_top = 336.0
-margin_right = 619.0
-margin_bottom = 344.0
+margin_top = 300.0
+margin_right = 577.0
+margin_bottom = 308.0
 
 [node name="ModInfo" type="RichTextLabel" parent="Main/Tabs/Mods"]
-margin_top = 350.0
-margin_right = 619.0
-margin_bottom = 470.0
-rect_min_size = Vector2( 0, 120 )
+margin_top = 312.0
+margin_right = 577.0
+margin_bottom = 412.0
+rect_min_size = Vector2( 0, 100 )
 focus_mode = 2
 custom_constants/line_separation = 4
 bbcode_enabled = true
@@ -435,31 +435,31 @@ visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
-margin_top = 35.5
+margin_top = 33.5
 margin_right = -7.5
 margin_bottom = -7.5
 size_flags_vertical = 3
 script = ExtResource( 15 )
 
 [node name="HBox" type="HBoxContainer" parent="Main/Tabs/Soundpacks"]
-margin_right = 619.0
-margin_bottom = 298.0
+margin_right = 577.0
+margin_bottom = 288.0
 
 [node name="Installed" type="VBoxContainer" parent="Main/Tabs/Soundpacks/HBox"]
-margin_right = 299.0
-margin_bottom = 298.0
+margin_right = 278.0
+margin_bottom = 288.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="Main/Tabs/Soundpacks/HBox/Installed"]
-margin_right = 299.0
-margin_bottom = 26.0
+margin_right = 278.0
+margin_bottom = 24.0
 text = "lbl_installed_sound"
 align = 1
 
 [node name="InstalledList" type="ItemList" parent="Main/Tabs/Soundpacks/HBox/Installed" groups=["disable_during_soundpack_operations"]]
-margin_top = 32.0
-margin_right = 299.0
-margin_bottom = 232.0
+margin_top = 28.0
+margin_right = 278.0
+margin_bottom = 228.0
 rect_min_size = Vector2( 0, 200 )
 size_flags_horizontal = 3
 items = [ "Item 0", null, false, "Item 1", null, false, "Item 2", null, false, "Item 3", null, false, "Item 4", null, false, "Item 5", null, false, "Item 6", null, false, "Item 7", null, false, "Item 8", null, false, "Item 9", null, false, "Item 10", null, false, "Item 11", null, false, "Item 12", null, false, "Item 13", null, false, "Item 14", null, false, "Item 15", null, false, "Item 16", null, false, "Item 17", null, false, "Item 18", null, false, "Item 19", null, false, "Item 20", null, false, "Item 21", null, false ]
@@ -467,45 +467,45 @@ same_column_width = true
 script = ExtResource( 17 )
 
 [node name="ShowStock" type="CheckBox" parent="Main/Tabs/Soundpacks/HBox/Installed" groups=["disable_during_soundpack_operations"]]
-margin_left = 73.0
-margin_top = 238.0
-margin_right = 225.0
-margin_bottom = 266.0
+margin_left = 67.0
+margin_top = 232.0
+margin_right = 210.0
+margin_bottom = 260.0
 hint_tooltip = "tooltip_stock_sound"
 size_flags_horizontal = 4
 text = "cbtn_stock_sound"
 
 [node name="BtnDelete" type="Button" parent="Main/Tabs/Soundpacks/HBox/Installed" groups=["disable_during_soundpack_operations"]]
-margin_left = 81.0
-margin_top = 272.0
-margin_right = 218.0
-margin_bottom = 298.0
+margin_left = 79.0
+margin_top = 264.0
+margin_right = 199.0
+margin_bottom = 288.0
 hint_tooltip = "tooltip_delete_sound"
 size_flags_horizontal = 4
 disabled = true
 text = "btn_delete_sound"
 
 [node name="VSeparator" type="VSeparator" parent="Main/Tabs/Soundpacks/HBox"]
-margin_left = 305.0
-margin_right = 313.0
-margin_bottom = 298.0
+margin_left = 284.0
+margin_right = 292.0
+margin_bottom = 288.0
 
 [node name="Downloadable" type="VBoxContainer" parent="Main/Tabs/Soundpacks/HBox"]
-margin_left = 319.0
-margin_right = 619.0
-margin_bottom = 298.0
+margin_left = 298.0
+margin_right = 577.0
+margin_bottom = 288.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="Main/Tabs/Soundpacks/HBox/Downloadable"]
-margin_right = 300.0
-margin_bottom = 26.0
+margin_right = 279.0
+margin_bottom = 24.0
 text = "lbl_avail_sound"
 align = 1
 
 [node name="AvailableList" type="ItemList" parent="Main/Tabs/Soundpacks/HBox/Downloadable" groups=["disable_during_soundpack_operations"]]
-margin_top = 32.0
-margin_right = 300.0
-margin_bottom = 232.0
+margin_top = 28.0
+margin_right = 279.0
+margin_bottom = 228.0
 rect_min_size = Vector2( 0, 200 )
 size_flags_horizontal = 3
 items = [ "Item 0", null, false, "Item 1", null, false, "Item 2", null, false, "Item 3", null, false ]
@@ -513,10 +513,10 @@ same_column_width = true
 script = ExtResource( 17 )
 
 [node name="BtnInstall" type="Button" parent="Main/Tabs/Soundpacks/HBox/Downloadable" groups=["disable_during_soundpack_operations"]]
-margin_left = 82.0
-margin_top = 238.0
-margin_right = 218.0
-margin_bottom = 264.0
+margin_left = 80.0
+margin_top = 232.0
+margin_right = 198.0
+margin_bottom = 256.0
 hint_tooltip = "tooltip_install_sound"
 size_flags_horizontal = 4
 disabled = true
@@ -554,246 +554,246 @@ visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
-margin_top = 35.5
+margin_top = 33.5
 margin_right = -7.5
 margin_bottom = -7.5
 script = ExtResource( 27 )
 
 [node name="FontSelection" type="HBoxContainer" parent="Main/Tabs/Fonts"]
-margin_right = 619.0
-margin_bottom = 398.0
+margin_right = 577.0
+margin_bottom = 336.0
 
 [node name="RightPane" type="VBoxContainer" parent="Main/Tabs/Fonts/FontSelection"]
-margin_right = 286.0
-margin_bottom = 398.0
+margin_right = 256.0
+margin_bottom = 336.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Fonts/FontSelection/RightPane"]
-margin_left = 90.0
-margin_right = 196.0
-margin_bottom = 26.0
+margin_left = 80.0
+margin_right = 176.0
+margin_bottom = 24.0
 size_flags_horizontal = 4
 text = "lbl_avail_fonts"
 align = 1
 
 [node name="FontsList" type="ItemList" parent="Main/Tabs/Fonts/FontSelection/RightPane"]
-margin_top = 32.0
-margin_right = 286.0
-margin_bottom = 282.0
-rect_min_size = Vector2( 0, 250 )
+margin_top = 28.0
+margin_right = 256.0
+margin_bottom = 243.0
+rect_min_size = Vector2( 0, 215 )
 size_flags_stretch_ratio = 2.0
 items = [ "Item 0", null, false, "Item 1", null, false, "Item 2", null, false, "Item 3", null, false ]
 allow_reselect = true
 
 [node name="Buttons" type="VBoxContainer" parent="Main/Tabs/Fonts/FontSelection/RightPane"]
-margin_top = 298.0
-margin_right = 286.0
-margin_bottom = 388.0
+margin_top = 250.0
+margin_right = 256.0
+margin_bottom = 332.0
 size_flags_vertical = 6
 
 [node name="Grid" type="GridContainer" parent="Main/Tabs/Fonts/FontSelection/RightPane/Buttons"]
-margin_right = 286.0
-margin_bottom = 58.0
+margin_right = 256.0
+margin_bottom = 54.0
 size_flags_horizontal = 4
 columns = 2
 
 [node name="BtnSetFontUI" type="Button" parent="Main/Tabs/Fonts/FontSelection/RightPane/Buttons/Grid"]
-margin_right = 144.0
-margin_bottom = 26.0
+margin_right = 129.0
+margin_bottom = 24.0
 hint_tooltip = "tooltip_set_font_ui"
 text = "btn_set_font_ui"
 
 [node name="BtnSetFontMap" type="Button" parent="Main/Tabs/Fonts/FontSelection/RightPane/Buttons/Grid"]
-margin_left = 150.0
-margin_right = 286.0
-margin_bottom = 26.0
+margin_left = 135.0
+margin_right = 256.0
+margin_bottom = 24.0
 hint_tooltip = "tooltip_set_font_map"
 text = "btn_set_font_map"
 
 [node name="BtnSetFontOvermap" type="Button" parent="Main/Tabs/Fonts/FontSelection/RightPane/Buttons/Grid"]
-margin_top = 32.0
-margin_right = 144.0
-margin_bottom = 58.0
+margin_top = 30.0
+margin_right = 129.0
+margin_bottom = 54.0
 hint_tooltip = "tooltip_set_font_omap"
 text = "btn_set_font_omap"
 
 [node name="BtnSetFontAll" type="Button" parent="Main/Tabs/Fonts/FontSelection/RightPane/Buttons/Grid"]
-margin_left = 150.0
-margin_top = 32.0
-margin_right = 286.0
-margin_bottom = 58.0
+margin_left = 135.0
+margin_top = 30.0
+margin_right = 256.0
+margin_bottom = 54.0
 hint_tooltip = "tooltip_set_font_all"
 text = "btn_set_font_all"
 
 [node name="BtnResetFont" type="Button" parent="Main/Tabs/Fonts/FontSelection/RightPane/Buttons"]
-margin_left = 86.0
-margin_top = 64.0
-margin_right = 200.0
-margin_bottom = 90.0
+margin_left = 78.0
+margin_top = 58.0
+margin_right = 178.0
+margin_bottom = 82.0
 hint_tooltip = "tooltip_reset_font"
 size_flags_horizontal = 4
 text = "btn_reset_font"
 
 [node name="VSeparator" type="VSeparator" parent="Main/Tabs/Fonts/FontSelection"]
-margin_left = 292.0
-margin_right = 300.0
-margin_bottom = 398.0
+margin_left = 262.0
+margin_right = 270.0
+margin_bottom = 336.0
 
 [node name="LeftPane" type="VBoxContainer" parent="Main/Tabs/Fonts/FontSelection"]
-margin_left = 306.0
-margin_right = 619.0
-margin_bottom = 398.0
+margin_left = 276.0
+margin_right = 577.0
+margin_bottom = 336.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 3.0
 custom_constants/separation = 4
 
 [node name="Label" type="Label" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_left = 96.0
-margin_right = 217.0
-margin_bottom = 26.0
+margin_left = 95.0
+margin_right = 205.0
+margin_bottom = 24.0
 size_flags_horizontal = 4
 text = "lbl_font_preview"
 align = 1
 
 [node name="Preview" type="RichTextLabel" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 30.0
-margin_right = 313.0
-margin_bottom = 180.0
-rect_min_size = Vector2( 0, 150 )
+margin_top = 28.0
+margin_right = 301.0
+margin_bottom = 128.0
+rect_min_size = Vector2( 0, 100 )
 custom_constants/line_separation = -2
 bbcode_enabled = true
 
 [node name="PreviewCyrillic" type="CheckBox" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_left = 67.0
-margin_top = 184.0
-margin_right = 246.0
-margin_bottom = 212.0
+margin_left = 69.0
+margin_top = 132.0
+margin_right = 231.0
+margin_bottom = 160.0
 hint_tooltip = "tooltip_preview_cyrillics"
 size_flags_horizontal = 4
 text = "cbtn_preview_cyrillics"
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 216.0
-margin_right = 313.0
-margin_bottom = 216.0
+margin_top = 164.0
+margin_right = 301.0
+margin_bottom = 164.0
 custom_constants/separation = 0
 
 [node name="OtherSettings" type="HBoxContainer" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
 margin_left = 78.0
-margin_top = 220.0
-margin_right = 234.0
-margin_bottom = 246.0
+margin_top = 168.0
+margin_right = 222.0
+margin_bottom = 192.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
 
 [node name="Label" type="Label" parent="Main/Tabs/Fonts/FontSelection/LeftPane/OtherSettings"]
-margin_right = 130.0
-margin_bottom = 26.0
+margin_right = 118.0
+margin_bottom = 24.0
 size_flags_horizontal = 4
 text = "lbl_other_settings"
 align = 1
 
 [node name="HelpIcon" parent="Main/Tabs/Fonts/FontSelection/LeftPane/OtherSettings" instance=ExtResource( 26 )]
-margin_left = 136.0
-margin_top = 3.0
-margin_right = 156.0
-margin_bottom = 23.0
+margin_left = 124.0
+margin_top = 2.0
+margin_right = 144.0
+margin_bottom = 22.0
 rect_min_size = Vector2( 20, 20 )
 hint_tooltip = "View detailed description of these settings."
 texture_normal = ExtResource( 30 )
 
 [node name="FontSizeUI" type="HBoxContainer" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 250.0
-margin_right = 313.0
-margin_bottom = 276.0
+margin_top = 196.0
+margin_right = 301.0
+margin_bottom = 220.0
 hint_tooltip = "tooltip_font_sz_ui"
 size_flags_vertical = 6
 
 [node name="Label" type="Label" parent="Main/Tabs/Fonts/FontSelection/LeftPane/FontSizeUI"]
-margin_right = 101.0
-margin_bottom = 26.0
+margin_right = 92.0
+margin_bottom = 24.0
 text = "lbl_font_sz_ui"
 
 [node name="sbFontSizeUI" type="SpinBox" parent="Main/Tabs/Fonts/FontSelection/LeftPane/FontSizeUI"]
-margin_left = 183.0
-margin_right = 313.0
-margin_bottom = 26.0
+margin_left = 201.0
+margin_right = 301.0
+margin_bottom = 24.0
 size_flags_horizontal = 10
 min_value = 8.0
 max_value = 64.0
 value = 8.0
 
 [node name="FontSizeMap" type="HBoxContainer" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 280.0
-margin_right = 313.0
-margin_bottom = 306.0
+margin_top = 224.0
+margin_right = 301.0
+margin_bottom = 248.0
 hint_tooltip = "tooltip_font_sz_map"
 size_flags_vertical = 6
 
 [node name="Label" type="Label" parent="Main/Tabs/Fonts/FontSelection/LeftPane/FontSizeMap"]
-margin_right = 118.0
-margin_bottom = 26.0
+margin_right = 108.0
+margin_bottom = 24.0
 hint_tooltip = "tooltip_font_sz_map"
 text = "lbl_font_sz_map"
 
 [node name="sbFontSizeMap" type="SpinBox" parent="Main/Tabs/Fonts/FontSelection/LeftPane/FontSizeMap"]
-margin_left = 183.0
-margin_right = 313.0
-margin_bottom = 26.0
+margin_left = 201.0
+margin_right = 301.0
+margin_bottom = 24.0
 size_flags_horizontal = 10
 min_value = 8.0
 max_value = 64.0
 value = 8.0
 
 [node name="FontSizeOvermap" type="HBoxContainer" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 310.0
-margin_right = 313.0
-margin_bottom = 336.0
+margin_top = 252.0
+margin_right = 301.0
+margin_bottom = 276.0
 hint_tooltip = "tooltip_font_sz_overmap"
 size_flags_vertical = 6
 
 [node name="Label" type="Label" parent="Main/Tabs/Fonts/FontSelection/LeftPane/FontSizeOvermap"]
-margin_right = 147.0
-margin_bottom = 26.0
+margin_right = 135.0
+margin_bottom = 24.0
 hint_tooltip = "tooltip_font_sz_overmap"
 text = "lbl_font_sz_overmap"
 
 [node name="sbFontSizeOM" type="SpinBox" parent="Main/Tabs/Fonts/FontSelection/LeftPane/FontSizeOvermap"]
-margin_left = 183.0
-margin_right = 313.0
-margin_bottom = 26.0
+margin_left = 201.0
+margin_right = 301.0
+margin_bottom = 24.0
 size_flags_horizontal = 10
 min_value = 8.0
 max_value = 64.0
 value = 8.0
 
 [node name="FontBlending" type="CheckButton" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 340.0
-margin_right = 313.0
-margin_bottom = 368.0
+margin_top = 280.0
+margin_right = 301.0
+margin_bottom = 308.0
 hint_tooltip = "tooltip_font_blending"
 text = "cbtn_font_blending"
 
 [node name="BtnSaveFontOptions" type="Button" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_left = 101.0
-margin_top = 372.0
-margin_right = 211.0
-margin_bottom = 398.0
+margin_left = 102.0
+margin_top = 312.0
+margin_right = 199.0
+margin_bottom = 336.0
 hint_tooltip = "tooltip_save_font"
 size_flags_horizontal = 4
 text = "btn_save_font"
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Fonts"]
-margin_top = 404.0
-margin_right = 619.0
-margin_bottom = 404.0
+margin_top = 340.0
+margin_right = 577.0
+margin_bottom = 340.0
 custom_constants/separation = 0
 
 [node name="FontConfigInfo" type="RichTextLabel" parent="Main/Tabs/Fonts"]
-margin_top = 410.0
-margin_right = 619.0
-margin_bottom = 486.0
+margin_top = 344.0
+margin_right = 577.0
+margin_bottom = 412.0
 bbcode_enabled = true
 bbcode_text = "Existing font configuration will be shown here.
 ...
@@ -818,28 +818,28 @@ visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
-margin_top = 35.5
+margin_top = 33.5
 margin_right = -7.5
 margin_bottom = -7.5
 script = ExtResource( 33 )
 
 [node name="Available" type="VBoxContainer" parent="Main/Tabs/Backups"]
-margin_right = 619.0
-margin_bottom = 264.0
+margin_right = 577.0
+margin_bottom = 256.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Backups/Available"]
-margin_right = 619.0
-margin_bottom = 26.0
+margin_right = 577.0
+margin_bottom = 24.0
 text = "lbl_save_backups"
 align = 1
 
 [node name="HBox" type="HBoxContainer" parent="Main/Tabs/Backups/Available"]
-margin_top = 32.0
-margin_right = 619.0
-margin_bottom = 232.0
+margin_top = 28.0
+margin_right = 577.0
+margin_bottom = 228.0
 
 [node name="BackupsList" type="ItemList" parent="Main/Tabs/Backups/Available/HBox" groups=["disable_during_backup_operations"]]
-margin_right = 306.0
+margin_right = 285.0
 margin_bottom = 200.0
 rect_min_size = Vector2( 0, 200 )
 size_flags_horizontal = 3
@@ -847,8 +847,8 @@ items = [ "Item 0", null, false, "Item 1", null, false, "Item 2", null, false, "
 same_column_width = true
 
 [node name="BackupInfo" type="RichTextLabel" parent="Main/Tabs/Backups/Available/HBox"]
-margin_left = 312.0
-margin_right = 619.0
+margin_left = 291.0
+margin_right = 577.0
 margin_bottom = 200.0
 focus_mode = 2
 size_flags_horizontal = 3
@@ -858,99 +858,99 @@ text = "Backup details will appear here."
 selection_enabled = true
 
 [node name="Buttons" type="HBoxContainer" parent="Main/Tabs/Backups/Available"]
-margin_top = 238.0
-margin_right = 619.0
-margin_bottom = 264.0
+margin_top = 232.0
+margin_right = 577.0
+margin_bottom = 256.0
 alignment = 1
 
 [node name="BtnRestore" type="Button" parent="Main/Tabs/Backups/Available/Buttons" groups=["disable_during_backup_operations"]]
-margin_left = 77.0
-margin_right = 227.0
-margin_bottom = 26.0
+margin_left = 76.0
+margin_right = 214.0
+margin_bottom = 24.0
 text = "btn_restore_backup"
 
 [node name="BtnDelete" type="Button" parent="Main/Tabs/Backups/Available/Buttons" groups=["disable_during_backup_operations"]]
-margin_left = 233.0
-margin_right = 377.0
-margin_bottom = 26.0
+margin_left = 220.0
+margin_right = 352.0
+margin_bottom = 24.0
 text = "btn_delete_backup"
 
 [node name="BtnRefresh" type="Button" parent="Main/Tabs/Backups/Available/Buttons" groups=["disable_during_backup_operations"]]
-margin_left = 383.0
-margin_right = 541.0
-margin_bottom = 26.0
+margin_left = 358.0
+margin_right = 501.0
+margin_bottom = 24.0
 text = "btn_refresh_backups"
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Backups"]
-margin_top = 270.0
-margin_right = 619.0
-margin_bottom = 278.0
+margin_top = 260.0
+margin_right = 577.0
+margin_bottom = 268.0
 
 [node name="Current" type="VBoxContainer" parent="Main/Tabs/Backups"]
-margin_top = 284.0
-margin_right = 619.0
-margin_bottom = 348.0
+margin_top = 272.0
+margin_right = 577.0
+margin_bottom = 328.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Backups/Current"]
-margin_right = 619.0
-margin_bottom = 26.0
+margin_right = 577.0
+margin_bottom = 24.0
 text = "lbl_manual_backup"
 align = 1
 
 [node name="HBox" type="HBoxContainer" parent="Main/Tabs/Backups/Current"]
-margin_top = 32.0
-margin_right = 619.0
-margin_bottom = 58.0
+margin_top = 28.0
+margin_right = 577.0
+margin_bottom = 52.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Backups/Current/HBox"]
-margin_right = 128.0
-margin_bottom = 26.0
+margin_right = 116.0
+margin_bottom = 24.0
 text = "lbl_backup_name"
 
 [node name="EditName" type="LineEdit" parent="Main/Tabs/Backups/Current/HBox"]
-margin_left = 134.0
-margin_right = 469.0
-margin_bottom = 26.0
+margin_left = 122.0
+margin_right = 439.0
+margin_bottom = 24.0
 size_flags_horizontal = 3
 placeholder_text = "Enter name for new backup"
 
 [node name="BtnCreate" type="Button" parent="Main/Tabs/Backups/Current/HBox" groups=["disable_during_backup_operations"]]
-margin_left = 475.0
-margin_right = 619.0
-margin_bottom = 26.0
+margin_left = 445.0
+margin_right = 577.0
+margin_bottom = 24.0
 size_flags_horizontal = 4
 text = "btn_create_backup"
 
 [node name="Spacer" type="Control" parent="Main/Tabs/Backups/Current"]
-margin_top = 64.0
-margin_right = 619.0
-margin_bottom = 64.0
+margin_top = 56.0
+margin_right = 577.0
+margin_bottom = 56.0
 
 [node name="Settings" type="VBoxContainer" parent="Main/Tabs"]
 visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
-margin_top = 35.5
+margin_top = 33.5
 margin_right = -7.5
 margin_bottom = -7.5
 custom_constants/separation = 2
 script = ExtResource( 8 )
 
 [node name="LauncherLanguage" type="HBoxContainer" parent="Main/Tabs/Settings"]
-margin_right = 619.0
-margin_bottom = 26.0
+margin_right = 577.0
+margin_bottom = 24.0
 hint_tooltip = "tooltip_num_releases_to_request"
 
 [node name="Label" type="Label" parent="Main/Tabs/Settings/LauncherLanguage"]
-margin_right = 163.0
-margin_bottom = 26.0
+margin_right = 144.0
+margin_bottom = 24.0
 text = "lbl_launcher_language"
 
 [node name="obtnLanguage" type="OptionButton" parent="Main/Tabs/Settings/LauncherLanguage"]
-margin_left = 439.0
-margin_right = 619.0
-margin_bottom = 26.0
+margin_left = 397.0
+margin_right = 577.0
+margin_bottom = 24.0
 rect_min_size = Vector2( 180, 0 )
 size_flags_horizontal = 10
 text = "English"
@@ -960,89 +960,89 @@ items = [ "English", ExtResource( 35 ), false, 0, null, "Русский", ExtRes
 selected = 0
 
 [node name="ShowGameDesc" type="CheckButton" parent="Main/Tabs/Settings"]
-margin_top = 28.0
-margin_right = 619.0
-margin_bottom = 56.0
+margin_top = 26.0
+margin_right = 577.0
+margin_bottom = 54.0
 hint_tooltip = "tooltip_show_game_desc"
 text = "cbtn_show_game_desc"
 
 [node name="PrintTips" type="CheckButton" parent="Main/Tabs/Settings"]
-margin_top = 58.0
-margin_right = 619.0
-margin_bottom = 86.0
+margin_top = 56.0
+margin_right = 577.0
+margin_bottom = 84.0
 hint_tooltip = "tooltip_print_tips"
 text = "cbtn_print_tips"
 
 [node name="UpdateToSame" type="CheckButton" parent="Main/Tabs/Settings"]
-margin_top = 88.0
-margin_right = 619.0
-margin_bottom = 116.0
+margin_top = 86.0
+margin_right = 577.0
+margin_bottom = 114.0
 hint_tooltip = "tooltip_updating_to_same_build"
 text = "cbtn_updating_to_same_build"
 
 [node name="ShortenNames" type="CheckButton" parent="Main/Tabs/Settings"]
-margin_top = 118.0
-margin_right = 619.0
-margin_bottom = 146.0
+margin_top = 116.0
+margin_right = 577.0
+margin_bottom = 144.0
 hint_tooltip = "tooltip_shorten_release_names"
 text = "cbtn_shorten_release_names"
 
 [node name="ShowObsoleteMods" type="CheckButton" parent="Main/Tabs/Settings"]
-margin_top = 148.0
-margin_right = 619.0
-margin_bottom = 176.0
+margin_top = 146.0
+margin_right = 577.0
+margin_bottom = 174.0
 hint_tooltip = "tooltip_show_obsolete_mods"
 text = "cbtn_show_obsolete_mods"
 
 [node name="InstallArchivedMods" type="CheckButton" parent="Main/Tabs/Settings"]
-margin_top = 178.0
-margin_right = 619.0
-margin_bottom = 206.0
+margin_top = 176.0
+margin_right = 577.0
+margin_bottom = 204.0
 hint_tooltip = "tooltip_install_archived_mods"
 text = "cbtn_install_archived_mods"
 
 [node name="ShowDebug" type="CheckButton" parent="Main/Tabs/Settings"]
-margin_top = 208.0
-margin_right = 619.0
-margin_bottom = 236.0
+margin_top = 206.0
+margin_right = 577.0
+margin_bottom = 234.0
 hint_tooltip = "tooltip_debug_mode"
 text = "cbtn_debug_mode"
 
 [node name="NumReleases" type="HBoxContainer" parent="Main/Tabs/Settings"]
-margin_top = 238.0
-margin_right = 619.0
-margin_bottom = 264.0
+margin_top = 236.0
+margin_right = 577.0
+margin_bottom = 260.0
 hint_tooltip = "tooltip_num_releases_to_request"
 
 [node name="Label" type="Label" parent="Main/Tabs/Settings/NumReleases"]
-margin_right = 205.0
-margin_bottom = 26.0
+margin_right = 185.0
+margin_bottom = 24.0
 text = "lbl_num_releases_to_request"
 
 [node name="sbNumReleases" type="SpinBox" parent="Main/Tabs/Settings/NumReleases"]
-margin_left = 489.0
-margin_right = 619.0
-margin_bottom = 26.0
+margin_left = 471.0
+margin_right = 577.0
+margin_bottom = 24.0
 size_flags_horizontal = 10
 min_value = 1.0
 value = 30.0
 rounded = true
 
 [node name="NumPrs" type="HBoxContainer" parent="Main/Tabs/Settings"]
-margin_top = 266.0
-margin_right = 619.0
-margin_bottom = 292.0
+margin_top = 262.0
+margin_right = 577.0
+margin_bottom = 286.0
 hint_tooltip = "tooltip_num_prs_to_request"
 
 [node name="Label" type="Label" parent="Main/Tabs/Settings/NumPrs"]
-margin_right = 171.0
-margin_bottom = 26.0
+margin_right = 156.0
+margin_bottom = 24.0
 text = "lbl_num_prs_to_request"
 
 [node name="sbNumPRs" type="SpinBox" parent="Main/Tabs/Settings/NumPrs"]
-margin_left = 489.0
-margin_right = 619.0
-margin_bottom = 26.0
+margin_left = 471.0
+margin_right = 577.0
+margin_bottom = 24.0
 size_flags_horizontal = 10
 min_value = 10.0
 step = 10.0
@@ -1050,31 +1050,31 @@ value = 100.0
 rounded = true
 
 [node name="ScaleOverride" type="HBoxContainer" parent="Main/Tabs/Settings"]
-margin_top = 294.0
-margin_right = 619.0
-margin_bottom = 322.0
+margin_top = 288.0
+margin_right = 577.0
+margin_bottom = 316.0
 hint_tooltip = "tooltip_ui_scale_override"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Label" type="Label" parent="Main/Tabs/Settings/ScaleOverride"]
-margin_top = 1.0
-margin_right = 150.0
-margin_bottom = 27.0
+margin_top = 2.0
+margin_right = 134.0
+margin_bottom = 26.0
 text = "lbl_ui_scale_override"
 
 [node name="cbScaleOverrideEnable" type="CheckBox" parent="Main/Tabs/Settings/ScaleOverride"]
-margin_left = 327.0
-margin_right = 483.0
+margin_left = 323.0
+margin_right = 465.0
 margin_bottom = 28.0
 size_flags_horizontal = 10
 size_flags_stretch_ratio = 20.0
 text = "cbtn_enable_scale"
 
 [node name="sbScaleOverride" type="SpinBox" parent="Main/Tabs/Settings/ScaleOverride"]
-margin_left = 489.0
-margin_right = 619.0
+margin_left = 471.0
+margin_right = 577.0
 margin_bottom = 28.0
 size_flags_horizontal = 10
 min_value = 75.0
@@ -1085,91 +1085,91 @@ editable = false
 suffix = "%"
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Settings"]
-margin_top = 324.0
-margin_right = 619.0
-margin_bottom = 332.0
+margin_top = 318.0
+margin_right = 577.0
+margin_bottom = 326.0
 
 [node name="Migration" type="VBoxContainer" parent="Main/Tabs/Settings"]
-margin_top = 334.0
-margin_right = 619.0
-margin_bottom = 438.0
+margin_top = 328.0
+margin_right = 577.0
+margin_bottom = 430.0
 hint_tooltip = "tooltip_data_to_migrate"
 custom_constants/separation = 2
 
 [node name="Label" type="Label" parent="Main/Tabs/Settings/Migration"]
-margin_right = 619.0
-margin_bottom = 26.0
+margin_right = 577.0
+margin_bottom = 24.0
 text = "lbl_data_to_migrate"
 
 [node name="Grid" type="GridContainer" parent="Main/Tabs/Settings/Migration"]
-margin_top = 28.0
-margin_right = 619.0
-margin_bottom = 104.0
+margin_top = 26.0
+margin_right = 577.0
+margin_bottom = 102.0
 custom_constants/vseparation = -4
 columns = 3
 
 [node name="Savegames" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_right = 145.0
+margin_right = 135.0
 margin_bottom = 28.0
 pressed = true
 text = "cbox_savegames"
 
 [node name="Fonts" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_left = 151.0
-margin_right = 302.0
+margin_left = 141.0
+margin_right = 281.0
 margin_bottom = 28.0
 pressed = true
 text = "cbox_fonts"
 
 [node name="Templates" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_left = 308.0
-margin_right = 446.0
+margin_left = 287.0
+margin_right = 416.0
 margin_bottom = 28.0
 pressed = true
 text = "cbox_templates"
 
 [node name="Settings" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
 margin_top = 24.0
-margin_right = 145.0
+margin_right = 135.0
 margin_bottom = 52.0
 pressed = true
 text = "cbox_settings"
 
 [node name="Tilesets" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_left = 151.0
+margin_left = 141.0
 margin_top = 24.0
-margin_right = 302.0
+margin_right = 281.0
 margin_bottom = 52.0
 pressed = true
 text = "cbox_tilesets"
 
 [node name="Memorial" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_left = 308.0
+margin_left = 287.0
 margin_top = 24.0
-margin_right = 446.0
+margin_right = 416.0
 margin_bottom = 52.0
 pressed = true
 text = "cbox_memorial"
 
 [node name="Mods" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
 margin_top = 48.0
-margin_right = 145.0
+margin_right = 135.0
 margin_bottom = 76.0
 pressed = true
 text = "cbox_mods"
 
 [node name="Soundpacks" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_left = 151.0
+margin_left = 141.0
 margin_top = 48.0
-margin_right = 302.0
+margin_right = 281.0
 margin_bottom = 76.0
 pressed = true
 text = "cbos_soundpacks"
 
 [node name="Graveyard" type="CheckBox" parent="Main/Tabs/Settings/Migration/Grid"]
-margin_left = 308.0
+margin_left = 287.0
 margin_top = 48.0
-margin_right = 446.0
+margin_right = 416.0
 margin_bottom = 76.0
 pressed = true
 text = "cbox_graveyard"
@@ -1179,7 +1179,7 @@ visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
-margin_top = 35.5
+margin_top = 33.5
 margin_right = -7.5
 margin_bottom = -7.5
 script = ExtResource( 14 )
@@ -1256,9 +1256,9 @@ size_flags_horizontal = 4
 text = "Test translation retrieval"
 
 [node name="Log" type="RichTextLabel" parent="Main"]
-margin_top = 389.0
-margin_right = 634.0
-margin_bottom = 784.0
+margin_top = 377.0
+margin_right = 592.0
+margin_bottom = 692.0
 focus_mode = 2
 size_flags_vertical = 3
 bbcode_enabled = true

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -57,7 +57,6 @@ margin_left = 8.0
 margin_top = 6.32009
 margin_right = -8.0
 margin_bottom = -9.67993
-custom_constants/separation = 4
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -82,9 +81,9 @@ items = [ "Cataclysm: Dark Days Ahead", null, false, 0, null, "Cataclysm: Bright
 selected = 0
 
 [node name="GameInfo" type="HBoxContainer" parent="Main"]
-margin_top = 30.0
+margin_top = 32.0
 margin_right = 634.0
-margin_bottom = 74.0
+margin_bottom = 76.0
 custom_constants/separation = 8
 
 [node name="Spacer" type="Control" parent="Main/GameInfo"]
@@ -114,26 +113,24 @@ text = "Game Title is a game in which... and other stuff about the game. This is
 fit_content_height = true
 
 [node name="Spacer" type="Control" parent="Main"]
-margin_top = 78.0
-margin_right = 634.0
-margin_bottom = 78.0
-
-[node name="Tabs" type="TabContainer" parent="Main" groups=["disable_during_backup_operations", "disable_during_mod_operations", "disable_during_soundpack_operations", "disable_while_fetching_releases", "disable_while_installing_game"]]
 margin_top = 82.0
 margin_right = 634.0
-margin_bottom = 565.0
+margin_bottom = 82.0
+
+[node name="Tabs" type="TabContainer" parent="Main" groups=["disable_during_backup_operations", "disable_during_mod_operations", "disable_during_soundpack_operations", "disable_while_fetching_releases", "disable_while_installing_game"]]
+margin_top = 88.0
+margin_right = 634.0
+margin_bottom = 383.0
 tab_align = 0
 script = ExtResource( 16 )
 
 [node name="Game" type="VBoxContainer" parent="Main/Tabs"]
-visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
 margin_top = 35.5
 margin_right = -7.5
 margin_bottom = -7.5
-custom_constants/separation = 8
 
 [node name="Channel" type="VBoxContainer" parent="Main/Tabs/Game"]
 margin_right = 619.0
@@ -182,9 +179,9 @@ group = SubResource( 1 )
 text = "rbtn_experimental"
 
 [node name="Builds" type="HBoxContainer" parent="Main/Tabs/Game"]
-margin_top = 68.0
+margin_top = 66.0
 margin_right = 619.0
-margin_bottom = 94.0
+margin_bottom = 92.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Game/Builds"]
 margin_right = 77.0
@@ -208,9 +205,9 @@ text = "btn_refresh"
 
 [node name="BtnInstall" type="Button" parent="Main/Tabs/Game" groups=["disable_while_fetching_releases", "disable_while_installing_game"]]
 margin_left = 189.0
-margin_top = 102.0
+margin_top = 98.0
 margin_right = 429.0
-margin_bottom = 134.0
+margin_bottom = 130.0
 rect_min_size = Vector2( 240, 32 )
 hint_tooltip = "tooltip_install"
 size_flags_horizontal = 4
@@ -219,14 +216,14 @@ icon = ExtResource( 2 )
 expand_icon = true
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Game"]
-margin_top = 142.0
+margin_top = 136.0
 margin_right = 619.0
-margin_bottom = 150.0
+margin_bottom = 144.0
 
 [node name="CurrentInstall" type="VBoxContainer" parent="Main/Tabs/Game"]
-margin_top = 158.0
+margin_top = 150.0
 margin_right = 619.0
-margin_bottom = 254.0
+margin_bottom = 246.0
 
 [node name="Label" type="Label" parent="Main/Tabs/Game/CurrentInstall"]
 margin_right = 619.0
@@ -269,9 +266,9 @@ icon = ExtResource( 3 )
 expand_icon = true
 
 [node name="Spacer" type="Control" parent="Main/Tabs/Game"]
-margin_top = 262.0
+margin_top = 252.0
 margin_right = 619.0
-margin_bottom = 262.0
+margin_bottom = 252.0
 
 [node name="ChangelogDialog" parent="Main/Tabs/Game" instance=ExtResource( 32 )]
 
@@ -418,18 +415,20 @@ selection_enabled = true
 
 [node name="DeleteMultipleDialog" type="ConfirmationDialog" parent="Main/Tabs/Mods"]
 margin_top = 648.0
-margin_right = 769.0
-margin_bottom = 770.0
+margin_right = 250.0
+margin_bottom = 748.0
 rect_min_size = Vector2( 300, 105 )
 window_title = "dlg_deleting_n_mods_title"
 dialog_text = "(this text is assigned at runtime)"
 dialog_autowrap = true
 
 [node name="ModReinstallDialog" parent="Main/Tabs/Mods" instance=ExtResource( 20 )]
-margin_left = 112.5
-margin_top = 149.34
-margin_right = 97.5
-margin_bottom = 95.34
+visible = false
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 476.0
+margin_right = 619.0
+margin_bottom = 477.0
 
 [node name="Soundpacks" type="VBoxContainer" parent="Main/Tabs"]
 visible = false
@@ -562,11 +561,11 @@ script = ExtResource( 27 )
 
 [node name="FontSelection" type="HBoxContainer" parent="Main/Tabs/Fonts"]
 margin_right = 619.0
-margin_bottom = 412.0
+margin_bottom = 398.0
 
 [node name="RightPane" type="VBoxContainer" parent="Main/Tabs/Fonts/FontSelection"]
 margin_right = 286.0
-margin_bottom = 412.0
+margin_bottom = 398.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 
@@ -588,9 +587,9 @@ items = [ "Item 0", null, false, "Item 1", null, false, "Item 2", null, false, "
 allow_reselect = true
 
 [node name="Buttons" type="VBoxContainer" parent="Main/Tabs/Fonts/FontSelection/RightPane"]
-margin_top = 305.0
+margin_top = 298.0
 margin_right = 286.0
-margin_bottom = 395.0
+margin_bottom = 388.0
 size_flags_vertical = 6
 
 [node name="Grid" type="GridContainer" parent="Main/Tabs/Fonts/FontSelection/RightPane/Buttons"]
@@ -639,12 +638,12 @@ text = "btn_reset_font"
 [node name="VSeparator" type="VSeparator" parent="Main/Tabs/Fonts/FontSelection"]
 margin_left = 292.0
 margin_right = 300.0
-margin_bottom = 412.0
+margin_bottom = 398.0
 
 [node name="LeftPane" type="VBoxContainer" parent="Main/Tabs/Fonts/FontSelection"]
 margin_left = 306.0
 margin_right = 619.0
-margin_bottom = 412.0
+margin_bottom = 398.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 3.0
 custom_constants/separation = 4
@@ -660,37 +659,31 @@ align = 1
 [node name="Preview" type="RichTextLabel" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
 margin_top = 30.0
 margin_right = 313.0
-margin_bottom = 190.0
-rect_min_size = Vector2( 0, 160 )
+margin_bottom = 180.0
+rect_min_size = Vector2( 0, 150 )
 custom_constants/line_separation = -2
 bbcode_enabled = true
 
 [node name="PreviewCyrillic" type="CheckBox" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
 margin_left = 67.0
-margin_top = 194.0
+margin_top = 184.0
 margin_right = 246.0
-margin_bottom = 222.0
+margin_bottom = 212.0
 hint_tooltip = "tooltip_preview_cyrillics"
 size_flags_horizontal = 4
 text = "cbtn_preview_cyrillics"
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 226.0
+margin_top = 216.0
 margin_right = 313.0
-margin_bottom = 226.0
-custom_constants/separation = 0
-
-[node name="HBoxContainer" type="HBoxContainer" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 230.0
-margin_right = 313.0
-margin_bottom = 230.0
+margin_bottom = 216.0
 custom_constants/separation = 0
 
 [node name="OtherSettings" type="HBoxContainer" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
 margin_left = 78.0
-margin_top = 234.0
+margin_top = 220.0
 margin_right = 234.0
-margin_bottom = 260.0
+margin_bottom = 246.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
 
@@ -711,9 +704,9 @@ hint_tooltip = "View detailed description of these settings."
 texture_normal = ExtResource( 30 )
 
 [node name="FontSizeUI" type="HBoxContainer" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 264.0
+margin_top = 250.0
 margin_right = 313.0
-margin_bottom = 290.0
+margin_bottom = 276.0
 hint_tooltip = "tooltip_font_sz_ui"
 size_flags_vertical = 6
 
@@ -732,9 +725,9 @@ max_value = 64.0
 value = 8.0
 
 [node name="FontSizeMap" type="HBoxContainer" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 294.0
+margin_top = 280.0
 margin_right = 313.0
-margin_bottom = 320.0
+margin_bottom = 306.0
 hint_tooltip = "tooltip_font_sz_map"
 size_flags_vertical = 6
 
@@ -754,9 +747,9 @@ max_value = 64.0
 value = 8.0
 
 [node name="FontSizeOvermap" type="HBoxContainer" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 324.0
+margin_top = 310.0
 margin_right = 313.0
-margin_bottom = 350.0
+margin_bottom = 336.0
 hint_tooltip = "tooltip_font_sz_overmap"
 size_flags_vertical = 6
 
@@ -776,31 +769,31 @@ max_value = 64.0
 value = 8.0
 
 [node name="FontBlending" type="CheckButton" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
-margin_top = 354.0
+margin_top = 340.0
 margin_right = 313.0
-margin_bottom = 382.0
+margin_bottom = 368.0
 hint_tooltip = "tooltip_font_blending"
 text = "cbtn_font_blending"
 
 [node name="BtnSaveFontOptions" type="Button" parent="Main/Tabs/Fonts/FontSelection/LeftPane"]
 margin_left = 101.0
-margin_top = 386.0
+margin_top = 372.0
 margin_right = 211.0
-margin_bottom = 412.0
+margin_bottom = 398.0
 hint_tooltip = "tooltip_save_font"
 size_flags_horizontal = 4
 text = "btn_save_font"
 
 [node name="HSeparator" type="HSeparator" parent="Main/Tabs/Fonts"]
-margin_top = 418.0
+margin_top = 404.0
 margin_right = 619.0
-margin_bottom = 418.0
+margin_bottom = 404.0
 custom_constants/separation = 0
 
 [node name="FontConfigInfo" type="RichTextLabel" parent="Main/Tabs/Fonts"]
-margin_top = 424.0
+margin_top = 410.0
 margin_right = 619.0
-margin_bottom = 500.0
+margin_bottom = 486.0
 bbcode_enabled = true
 bbcode_text = "Existing font configuration will be shown here.
 ...
@@ -813,11 +806,12 @@ text = "Existing font configuration will be shown here.
 fit_content_height = true
 
 [node name="FontSizeHelpDialog" parent="Main/Tabs/Fonts" instance=ExtResource( 29 )]
+visible = false
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_top = 538.0
-margin_right = 769.0
-margin_bottom = 539.0
+margin_top = 492.0
+margin_right = 619.0
+margin_bottom = 493.0
 
 [node name="Backups" type="VBoxContainer" parent="Main/Tabs"]
 visible = false
@@ -933,6 +927,7 @@ margin_right = 619.0
 margin_bottom = 64.0
 
 [node name="Settings" type="VBoxContainer" parent="Main/Tabs"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 7.5
@@ -1097,9 +1092,9 @@ margin_bottom = 332.0
 [node name="Migration" type="VBoxContainer" parent="Main/Tabs/Settings"]
 margin_top = 334.0
 margin_right = 619.0
-margin_bottom = 440.0
+margin_bottom = 438.0
 hint_tooltip = "tooltip_data_to_migrate"
-custom_constants/separation = 4
+custom_constants/separation = 2
 
 [node name="Label" type="Label" parent="Main/Tabs/Settings/Migration"]
 margin_right = 619.0
@@ -1107,9 +1102,9 @@ margin_bottom = 26.0
 text = "lbl_data_to_migrate"
 
 [node name="Grid" type="GridContainer" parent="Main/Tabs/Settings/Migration"]
-margin_top = 30.0
+margin_top = 28.0
 margin_right = 619.0
-margin_bottom = 106.0
+margin_bottom = 104.0
 custom_constants/vseparation = -4
 columns = 3
 
@@ -1261,7 +1256,7 @@ size_flags_horizontal = 4
 text = "Test translation retrieval"
 
 [node name="Log" type="RichTextLabel" parent="Main"]
-margin_top = 569.0
+margin_top = 389.0
 margin_right = 634.0
 margin_bottom = 784.0
 focus_mode = 2

--- a/scenes/ChangelogDialog.tscn
+++ b/scenes/ChangelogDialog.tscn
@@ -68,7 +68,7 @@ margin_top = 263.0
 margin_right = 260.0
 margin_bottom = 292.0
 size_flags_horizontal = 4
-text = "Close"
+text = "btn_close"
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/scenes/FontSizeHelpDialog.tscn
+++ b/scenes/FontSizeHelpDialog.tscn
@@ -25,19 +25,18 @@ __meta__ = {
 [node name="Margin" type="MarginContainer" parent="Panel"]
 margin_left = 14.0
 margin_top = 14.0
-margin_right = 636.0
-margin_bottom = 786.0
+margin_right = 586.0
+margin_bottom = 686.0
 custom_constants/margin_top = 8
 custom_constants/margin_bottom = 8
 
 [node name="VBox" type="VBoxContainer" parent="Panel/Margin"]
-margin_top = 8.0
-margin_right = 622.0
-margin_bottom = 764.0
+margin_right = 572.0
+margin_bottom = 664.0
 
 [node name="Help" type="RichTextLabel" parent="Panel/Margin/VBox"]
-margin_right = 622.0
-margin_bottom = 711.0
+margin_right = 572.0
+margin_bottom = 619.0
 size_flags_vertical = 3
 custom_fonts/bold_italics_font = ExtResource( 2 )
 custom_fonts/italics_font = ExtResource( 3 )
@@ -48,10 +47,10 @@ bbcode_text = "dlg_font_config_help"
 text = "dlg_font_config_help"
 
 [node name="BtnOK" type="Button" parent="Panel/Margin/VBox"]
-margin_left = 270.0
-margin_top = 719.0
-margin_right = 352.0
-margin_bottom = 756.0
+margin_left = 245.0
+margin_top = 627.0
+margin_right = 327.0
+margin_bottom = 664.0
 size_flags_horizontal = 4
 text = "Close"
 

--- a/scenes/FontSizeHelpDialog.tscn
+++ b/scenes/FontSizeHelpDialog.tscn
@@ -7,6 +7,7 @@
 [ext_resource path="res://scripts/FontSizeHelpDialog.gd" type="Script" id=5]
 
 [node name="FontSizeHelpDialog" type="WindowDialog"]
+visible = true
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource( 5 )
@@ -24,20 +25,19 @@ __meta__ = {
 [node name="Margin" type="MarginContainer" parent="Panel"]
 margin_left = 14.0
 margin_top = 14.0
-margin_right = 786.0
-margin_bottom = 986.0
+margin_right = 636.0
+margin_bottom = 786.0
 custom_constants/margin_top = 8
 custom_constants/margin_bottom = 8
 
 [node name="VBox" type="VBoxContainer" parent="Panel/Margin"]
 margin_top = 8.0
-margin_right = 772.0
-margin_bottom = 964.0
-custom_constants/separation = 16
+margin_right = 622.0
+margin_bottom = 764.0
 
 [node name="Help" type="RichTextLabel" parent="Panel/Margin/VBox"]
-margin_right = 772.0
-margin_bottom = 903.0
+margin_right = 622.0
+margin_bottom = 711.0
 size_flags_vertical = 3
 custom_fonts/bold_italics_font = ExtResource( 2 )
 custom_fonts/italics_font = ExtResource( 3 )
@@ -48,10 +48,10 @@ bbcode_text = "dlg_font_config_help"
 text = "dlg_font_config_help"
 
 [node name="BtnOK" type="Button" parent="Panel/Margin/VBox"]
-margin_left = 345.0
-margin_top = 919.0
-margin_right = 427.0
-margin_bottom = 956.0
+margin_left = 270.0
+margin_top = 719.0
+margin_right = 352.0
+margin_bottom = 756.0
 size_flags_horizontal = 4
 text = "Close"
 

--- a/scenes/ModReinstallDialog.tscn
+++ b/scenes/ModReinstallDialog.tscn
@@ -3,8 +3,11 @@
 [ext_resource path="res://scripts/ModReinstallDialog.gd" type="Script" id=1]
 
 [node name="ModReinstallDialog" type="WindowDialog"]
+visible = true
 anchor_right = 1.0
 anchor_bottom = 0.268
+margin_right = -150.0
+margin_bottom = -14.4
 size_flags_horizontal = 3
 size_flags_vertical = 3
 window_title = "dlg_mod_reinstall_title"
@@ -23,8 +26,8 @@ __meta__ = {
 [node name="Margin" type="MarginContainer" parent="Panel"]
 margin_left = 14.0
 margin_top = 14.0
-margin_right = 786.0
-margin_bottom = 254.0
+margin_right = 486.0
+margin_bottom = 186.0
 custom_constants/margin_right = 16
 custom_constants/margin_top = 16
 custom_constants/margin_left = 16
@@ -35,16 +38,16 @@ __meta__ = {
 
 [node name="VBox" type="VBoxContainer" parent="Panel/Margin"]
 margin_left = 16.0
-margin_top = 65.0
-margin_right = 756.0
-margin_bottom = 174.0
+margin_top = 31.0
+margin_right = 456.0
+margin_bottom = 140.0
 size_flags_vertical = 4
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Label" type="Label" parent="Panel/Margin/VBox"]
-margin_right = 740.0
+margin_right = 440.0
 margin_bottom = 56.0
 text = "(this text is assigned at runtime)
 (this text is assigned at runtime)"
@@ -53,36 +56,35 @@ autowrap = true
 
 [node name="Spacer" type="Control" parent="Panel/Margin/VBox"]
 margin_top = 64.0
-margin_right = 740.0
+margin_right = 440.0
 margin_bottom = 64.0
 
 [node name="HBox" type="HBoxContainer" parent="Panel/Margin/VBox"]
-margin_left = 214.0
+margin_left = 8.0
 margin_top = 72.0
-margin_right = 525.0
+margin_right = 432.0
 margin_bottom = 109.0
 size_flags_horizontal = 4
-custom_constants/separation = 16
 
 [node name="BtnYes" type="Button" parent="Panel/Margin/VBox/HBox"]
-margin_right = 115.0
+margin_right = 157.0
 margin_bottom = 37.0
 size_flags_horizontal = 4
-text = "Reinstall"
+text = "btn_reinstall"
 
 [node name="BtnNo" type="Button" parent="Panel/Margin/VBox/HBox"]
-margin_left = 131.0
-margin_right = 200.0
+margin_left = 165.0
+margin_right = 278.0
 margin_bottom = 37.0
 size_flags_horizontal = 4
-text = "Skip"
+text = "btn_skip"
 
 [node name="BtnCancel" type="Button" parent="Panel/Margin/VBox/HBox"]
-margin_left = 216.0
-margin_right = 311.0
+margin_left = 286.0
+margin_right = 424.0
 margin_bottom = 37.0
 size_flags_horizontal = 4
-text = "Cancel"
+text = "btn_cancel"
 
 [connection signal="pressed" from="Panel/Margin/VBox/HBox/BtnYes" to="." method="_on_BtnYes_pressed"]
 [connection signal="pressed" from="Panel/Margin/VBox/HBox/BtnNo" to="." method="_on_BtnNo_pressed"]

--- a/scripts/Catapult.gd
+++ b/scripts/Catapult.gd
@@ -69,62 +69,6 @@ func _unpack_utils() -> void:
 		d.copy("res://utils/unzip.exe", unzip_exe)
 
 
-func apply_ui_scale() -> void:
-	# Scale all kinds of fixed sizes with DPI.
-	
-	_self.get_font("DynamicFont").size = 14.0 * _geom.scale
-	
-	for node in [_game_desc, _log, _mod_info]:
-		for font_prop in [
-			"custom_fonts/normal_font",
-			"custom_fonts/italics_font",
-			"custom_fonts/bold_font",
-			"custom_fonts/bold_italics_font"
-			]:
-			node.get(font_prop).size = 14.0 * _geom.scale
-	
-	for node in _get_all_nodes($"/root"):
-		for property in [
-				"custom_constants/separation",
-				"rect_min_size",
-				]:
-			_try_scale_property(node, property, _geom.scale)
-			
-	var theme: Theme = _self.theme
-	for node_type in ["CheckButton", "CheckBox", "SpinBox"]:
-		for icon in theme.get_icon_list(node_type):
-			_try_scale_property(theme.get_icon(icon, node_type), "size", _geom.scale)
-	
-
-
-func _try_scale_property(obj: Object, prop: String, multiplier: float) -> void:
-	
-#	var value = obj.get(prop)
-#	if (value) and (typeof(value) in [TYPE_INT, TYPE_REAL, TYPE_VECTOR2, TYPE_RECT2]):
-#		if [obj, prop] in _ui_staring_sizes:
-#			obj.set(prop, _ui_staring_sizes[[obj, prop]] * multiplier)
-#		else:
-#			obj.set(prop, value * multiplier)
-#			_ui_staring_sizes[[obj, prop]] = value
-#		print("Node: %s, property: %s, new value: %s" % [obj.name, prop, obj.get(prop)])
-
-	if (not prop in obj) or (obj[prop] == null):
-		return
-	
-	var curr_value
-	if [obj, prop] in _ui_staring_sizes:
-		curr_value = _ui_staring_sizes[[obj, prop]]
-	else:
-		curr_value = obj.get(prop)
-		_ui_staring_sizes[[obj, prop]] = curr_value
-	
-	var new_value = curr_value * multiplier
-	if typeof(curr_value) == TYPE_INT:
-		new_value = int(round(new_value))
-	
-	obj.set(prop, new_value)
-
-
 func _get_all_nodes(within: Node) -> Array:
 	
 	var result = []

--- a/scripts/ChangelogDialod.gd
+++ b/scripts/ChangelogDialod.gd
@@ -6,10 +6,9 @@ const _PR_URL = {
 	"bn": "https://api.github.com/search/issues?q=repo%3Acataclysmbnteam/Cataclysm-BN",
 }
 
-
-onready var _settings = $"/root/SettingsManager"
-onready var _pullRequests = $PullRequests
-onready var _changelogTextBox = $Panel/Margin/VBox/ChangelogText
+onready var _settings := $"/root/SettingsManager"
+onready var _pullRequests := $PullRequests
+onready var _changelogTextBox := $Panel/Margin/VBox/ChangelogText
 
 var _pr_data = ""
 
@@ -17,9 +16,7 @@ var _pr_data = ""
 func open() -> void:
 	
 	download_pull_requests()
-	rect_min_size = get_tree().root.size * Vector2(0.9, 0.9)
-	set_as_minsize()
-	popup_centered()
+	popup_centered_ratio(0.9)
 
 
 func download_pull_requests():

--- a/scripts/FontSizeHelpDialog.gd
+++ b/scripts/FontSizeHelpDialog.gd
@@ -1,29 +1,15 @@
 extends WindowDialog
 
 
-const _IMG1_RES := "res://images/font-sizes.png"
-const _IMG2_RES := "res://images/font-rect.png"
-
-const _IMG1_SZ := 200
-const _IMG2_SZ := 450
-
-onready var _geom := $"/root/WindowGeometry"
 onready var _label := $Panel/Margin/VBox/Help
 
 
 func open() -> void:
 	
-	var text := tr("dlg_font_config_help")
-	var img1_size := int(_IMG1_SZ * _geom.scale)
-	var img2_size := int(_IMG2_SZ * _geom.scale)
-	text = text.replace("IMG_1", "[img=%s]%s[/img]" % [img1_size, _IMG1_RES])
-	text = text.replace("IMG_2", "[img=%s]%s[/img]" % [img2_size, _IMG2_RES])
-	_label.bbcode_text = text
+	_label.bbcode_text = tr("dlg_font_config_help")
 	_label.scroll_to_line(0)
 #
-	rect_min_size = get_tree().root.size * Vector2(0.9, 0.9)
-	set_as_minsize()
-	popup_centered()
+	popup_centered_ratio(0.9)
 
 
 func _on_BtnOK_pressed() -> void:

--- a/scripts/FontsUI.gd
+++ b/scripts/FontsUI.gd
@@ -166,7 +166,7 @@ func _on_FontsList_item_selected(index: int) -> void:
 	var font_res = DynamicFont.new()
 	
 	font_res.font_data = load(font_path)
-	font_res.size = 15.0 * _geom.scale
+	font_res.size = 15.0
 	
 	_preview.add_font_override("normal_font", font_res)
 	_preview.bbcode_text = _make_preview_string(_settings.read("font_preview_cyrillic"))

--- a/scripts/FontsUI.gd
+++ b/scripts/FontsUI.gd
@@ -78,9 +78,6 @@ func _make_preview_string(cyrillic: bool = false) -> String:
 	var index = _rng.randi_range(0, len(_PREVIEW_TEXT_NUM) - 1)
 	var result = _PREVIEW_TEXT_NUM
 	
-	index = _rng.randi_range(0, len(_PREVIEW_TEXT_EN) - 1)
-	result += "\n\n" + _PREVIEW_TEXT_EN[index]
-	
 	if _settings.read("font_preview_cyrillic"):
 		index = _rng.randi_range(0, len(_PREVIEW_TEXT_RU) - 1)
 		result += "\n\n" + _PREVIEW_TEXT_RU[index]

--- a/scripts/ModReinstallDialog.gd
+++ b/scripts/ModReinstallDialog.gd
@@ -4,7 +4,6 @@ extends WindowDialog
 signal response_yes
 signal response_no
 
-
 onready var _label = $Panel/Margin/VBox/Label
 
 
@@ -15,8 +14,7 @@ func open(num_mods: int) -> void:
 	else:
 		_label.text = tr("dlg_mod_reinstall_text_multiple") % num_mods
 	
-	rect_min_size = get_tree().root.size * Vector2(0.6, 0.2)
-	set_as_minsize()
+	rect_size = Vector2(400, 150)
 	popup_centered()
 
 

--- a/scripts/ModsUI.gd
+++ b/scripts/ModsUI.gd
@@ -3,7 +3,7 @@ extends VBoxContainer
 
 signal status_message
 
-
+onready var _root = $"/root/Catapult"
 onready var _mods = $"../../../Mods"
 onready var _settings = $"/root/SettingsManager"
 onready var _installed_list = $HBox/Installed/InstalledList
@@ -298,8 +298,7 @@ func _on_BtnDelete_pressed() -> void:
 	var num = len(_mods_to_delete)
 	if num > 1:
 		_dlg_del_multiple.dialog_text = tr("dlg_deleting_n_mods_text") % num
-		_dlg_del_multiple.rect_min_size = get_tree().root.size * Vector2(0.4, 0.1)
-		_dlg_del_multiple.set_as_minsize()
+		_dlg_del_multiple.rect_size = Vector2(250, 100)
 		_dlg_del_multiple.popup_centered()
 		return
 	

--- a/scripts/SoundpacksUI.gd
+++ b/scripts/SoundpacksUI.gd
@@ -103,8 +103,7 @@ func _on_BtnDelete_pressed() -> void:
 	
 	var name = _installed_packs[_installed_list.get_selected_items()[0]]["name"]
 	_dlg_confirm_del.dialog_text = tr("dlg_sound_deletion_text") % name
-	_dlg_confirm_del.rect_min_size = get_tree().root.size * Vector2(0.6, 0.1)
-	_dlg_confirm_del.set_as_minsize()
+	_dlg_confirm_del.rect_size = Vector2(200, 100)
 	_dlg_confirm_del.popup_centered()
 
 
@@ -137,8 +136,7 @@ func _on_BtnInstall_pressed() -> void:
 	var pack = _sound.SOUNDPACKS[pack_index]
 	
 	if ("manual_download" in pack) and (pack["manual_download"] == true):
-		_dlg_manual_dl.rect_min_size = get_tree().root.size * Vector2(0.6, 0.2)
-		_dlg_manual_dl.set_as_minsize()
+		_dlg_manual_dl.rect_size = Vector2(300, 150)
 		_dlg_manual_dl.popup_centered()
 	else:
 		if _is_pack_installed(pack["name"]):

--- a/scripts/window_geometry.gd
+++ b/scripts/window_geometry.gd
@@ -18,8 +18,11 @@ func _set_scale(new_scale: float) -> void:
 
 func _apply_scale() -> void:
 	
-	OS.set_window_size(Vector2(650, 800) * scale)
-	$"/root/Catapult".call_deferred("apply_ui_scale")
+	var final_scale := scale if fmod(scale, 1.0) == 0 else scale + 0.002
+	# This is a workaround for weird font aliasing that shows up when the scale
+	# is a simple rational fraction, like 125% (5/4) or 150% (3/2).
+	
+	OS.set_window_size(Vector2(650, 800) * final_scale)
 
 
 func calculate_scale_from_dpi() -> float:

--- a/scripts/window_geometry.gd
+++ b/scripts/window_geometry.gd
@@ -22,13 +22,17 @@ func _apply_scale() -> void:
 	# This is a workaround for weird font aliasing that shows up when the scale
 	# is a simple rational fraction, like 125% (5/4) or 150% (3/2).
 	
-	OS.set_window_size(Vector2(650, 800) * final_scale)
+	var base_size := Vector2(
+		ProjectSettings.get("display/window/size/width"),
+		ProjectSettings.get("display/window/size/height"))
+	
+	OS.set_window_size(base_size * final_scale)
 
 
 func calculate_scale_from_dpi() -> float:
 	
 	var ratio = OS.get_screen_dpi() / 96.0
-	return round(ratio / 0.125) * 0.125
+	return stepify(ratio, 0.125)
 
 
 func _on_SceneTree_idle():

--- a/text/text.csv
+++ b/text/text.csv
@@ -172,11 +172,11 @@ setting a font.","Нажмите, чтобы записать эти настр�
 ,,
 "dlg_font_config_help","As you've probably already noticed, you can set a separate font for game UI, map and overmap. Additionally, each of these three fonts in Cataclysm has three size parameters that define how it is drawn. They can be set in the game under [i]Settings > Graphics > Font Settings[/i].
 
-[img=200]res://images/font-sizes.png[/img]
+[img=180]res://images/font-sizes.png[/img]
 
 [b]Font Height[/b] and [b]Font Width[/b] define the pixel size of the rectangle reserved for each character. If this rectangle is too small, the letters will be clipped. If it is too large, they will be far apart and appear undersized.
 
-[img=450]res://images/font-rect.png[/img]
+[img=400]res://images/font-rect.png[/img]
 
 [b]Font Size[/b] is the actual size at which font glyphs will always be rendered, whether they fit into reserved space or not.
 
@@ -191,11 +191,11 @@ It is also recommended to turn on [b]Font Blending[/b] for smoother font renderi
 
 ","Как вы, наверное, уже заметили, вы можете установить размер шрифта отдельно для интерфейса, мира и карты. Дополнительно, каждый из этих трёх шрифтов в Катаклизме имеет три параметра, определяющие, как он отрисовывается. В игре их можно задать через [i]Настройки > Графика > Настройки шрифта[/i].
 
-[img=200]res://images/font-sizes.png[/img]
+[img=180]res://images/font-sizes.png[/img]
 
 [b]Высота шрифта[/b] и [b]Ширина шрифта[/b] отвечают за размер прямоугольной области (в пикселях), отводимой каждому символу. Если этот прямоугольник будет слишком маленьким, буквы будут обрезаны. Если он будет слишком большим, буквы будут слишком далеко друг от друга.
 
-[img=450]res://images/font-rect.png[/img]
+[img=400]res://images/font-rect.png[/img]
 
 Параметр [b]Размер шрифта[/b] — это истинный размер, с которым всегда будут отрисовываться символы шрифта, умещаются они в отведенное простанство или нет.
 

--- a/text/text.csv
+++ b/text/text.csv
@@ -172,11 +172,11 @@ setting a font.","Нажмите, чтобы записать эти настр�
 ,,
 "dlg_font_config_help","As you've probably already noticed, you can set a separate font for game UI, map and overmap. Additionally, each of these three fonts in Cataclysm has three size parameters that define how it is drawn. They can be set in the game under [i]Settings > Graphics > Font Settings[/i].
 
-IMG_1
+[img=200]res://images/font-sizes.png[/img]
 
 [b]Font Height[/b] and [b]Font Width[/b] define the pixel size of the rectangle reserved for each character. If this rectangle is too small, the letters will be clipped. If it is too large, they will be far apart and appear undersized.
 
-IMG_2
+[img=450]res://images/font-rect.png[/img]
 
 [b]Font Size[/b] is the actual size at which font glyphs will always be rendered, whether they fit into reserved space or not.
 
@@ -191,11 +191,11 @@ It is also recommended to turn on [b]Font Blending[/b] for smoother font renderi
 
 ","Как вы, наверное, уже заметили, вы можете установить размер шрифта отдельно для интерфейса, мира и карты. Дополнительно, каждый из этих трёх шрифтов в Катаклизме имеет три параметра, определяющие, как он отрисовывается. В игре их можно задать через [i]Настройки > Графика > Настройки шрифта[/i].
 
-IMG_1
+[img=200]res://images/font-sizes.png[/img]
 
 [b]Высота шрифта[/b] и [b]Ширина шрифта[/b] отвечают за размер прямоугольной области (в пикселях), отводимой каждому символу. Если этот прямоугольник будет слишком маленьким, буквы будут обрезаны. Если он будет слишком большим, буквы будут слишком далеко друг от друга.
 
-IMG_2
+[img=450]res://images/font-rect.png[/img]
 
 Параметр [b]Размер шрифта[/b] — это истинный размер, с которым всегда будут отрисовываться символы шрифта, умещаются они в отведенное простанство или нет.
 
@@ -443,3 +443,13 @@ into the new game version when updating.","Выберите, какие игро
 "msg_fetching_releases_dda","Fetching releases for DDA Experimental...","Получение списка экспериментальных релизов DDA…"
 "msg_fetching_releases_bn","Fetching releases for BN Experimental…","Получение списка экспериментальных релизов BN…"
 "msg_invalid_fetch_func_param","ReleaseManager.fetch() was passed %s","В ReleaseManager.fetch() был передан аргумент %s"
+,,
+" ==== DIALOG BUTTONS ====",,
+,,
+"btn_close","Close","Закрыть"
+"btn_ok","OK","ОК"
+"btn_cancel","Cancel","Отмена"
+"btn_yes","Yes","Да"
+"btn_no","No","Нет"
+"btn_reinstall","Reinstall","Переустановить"
+"btn_skip","Skip","Пропустить"


### PR DESCRIPTION
This changes from UI scaling by manually setting element sizes to 2d viewport scaling (with font supersampling).
Also, numerous UI and theme tweaks were done to compact the interface.

Thanks to all this, occasional oddly sized elements are now gone, and the whole UI looks a lot more uniform. All elements have the same relative sizes at any scale, so UI layouts are now very predictable and much easier to design.

The window is now smaller (so it fits on 1366x768 screens at 100% scale), and fonts and controls are sized more reasonably on standard DPI screens.