### PR TITLE
Added hours and minutes to backup default name

### DIFF
--- a/scripts/BackupsUI.gd
+++ b/scripts/BackupsUI.gd
@@ -26,10 +26,12 @@ func _refresh_available() -> void:
 func _populate_default_new_name() -> void:
 	
 	var datetime = OS.get_datetime()
-	_edit_name.text = "Manual_%02d-%02d-%02d" % [
+	_edit_name.text = "Manual_%02d-%02d-%02d_%02d-%02d" % [
 		datetime["year"] % 100,
 		datetime["month"],
-		datetime["day"]
+		datetime["day"],
+		datetime["hour"],
+		datetime["minute"],
 	]
 
 


### PR DESCRIPTION
I think it would be better to also have the hours and minutes so that the _"Backup already exists"_ warning doesn't show if we want to create more than one backup per day.