### PR TITLE
Added focus to at least one button when UI starts

### DIFF
--- a/scripts/Catapult.gd
+++ b/scripts/Catapult.gd
@@ -46,6 +46,8 @@ func _ready() -> void:
 	
 	assign_localized_text()
 	
+	_btn_resume.grab_focus()
+	
 	var welcome_msg = tr("str_welcome")
 	if Settings.read("print_tips_of_the_day"):
 		welcome_msg += tr("str_tip_of_the_day") + TOTD.get_tip() + "\n"


### PR DESCRIPTION
I focused just one button (the Resume Las World one) to add minimal accessibility for keyboard arrows/tabbing navigation for users that rely only on those methods of movement, otherwise not even the main "play" buttons are ever selected if not for the help of a mouse.
It's very basic but it's a starting point.