### PR TITLE
Update backup name when app gains focus

### DIFF
--- a/scripts/BackupsUI.gd
+++ b/scripts/BackupsUI.gd
@@ -44,6 +44,13 @@ func _on_Tabs_tab_changed(tab: int) -> void:
 	_populate_default_new_name()
 
 
+## Update the default backup filename when the app gains focus.
+func _notification(what: int) -> void:
+
+	if what == MainLoop.NOTIFICATION_WM_FOCUS_IN:
+		_populate_default_new_name()
+
+
 func _on_BtnCreate_pressed():
 
 	var target_file = _edit_name.text


### PR DESCRIPTION
My usual use of the backup system looks like:

1. Launch game
2. Play
3. Save game
4. Switch from game to Catapult
5. Switch to Backups tab
6. Click "create"
7. Switch back to game
8. Play
9. Save game
10. Switch from game to Catapult
11. Switch to some tab that isn't Backups  # wait, what?
12. GOTO 5

This changeset removes the need to switch tabs to update the timestamp-based backup name.