### PR TITLE
Change audio driver to "Dummy" to stop Catapult from preventing system sleep

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -57,6 +57,7 @@ config/windows_native_icon="res://icons/appicon.ico"
 [audio]
 
 default_bus_layout=""
+driver="Dummy"
 
 [autoload]
 


### PR DESCRIPTION
So I noticed that the Catapult launcher is stopping my system from going to sleep mode automatically. 

Apparently this is a [known issue](https://github.com/godotengine/godot/issues/28039) in Godot and the only fix I saw was to disable the audio driver by setting it to "Dummy".

But Catapult doesn't emit any audio anyway, right? So this should not be a problem.

You can test this change on your own windows system by running the `powercfg -requests` command in a admin command prompt. It will say what's currently preventing the system from going to sleep.