### PR TITLE
Add Fedora Linux instructions for installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ None required. The launcher is a single, self-contained executable. Just [downlo
 - The game needs the following dependencies, Some distros come with these preinstalled, but others don't.: `sdl2`, `sdl2_image`, `sdl2_ttf`, `sdl2_mixer`, `freetype2`
     - On Debian based distros (Ubuntu, Mint, etc.): `sudo apt install libsdl2-image libsdl2-ttf libsdl2-mixer libfreetype6`
     - On Arch based distros `sudo pacman -S sdl2 sdl2_image sdl2_ttf sdl2_mixer`
+    - On Fedora based distros `sudo dnf install SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype`
 
 #### Packaging
 


### PR DESCRIPTION
I noticed you had instructions for Debian-based distros and Arch-based distros, but none for Fedora-based distros. Thus, I thought I'd add them. The command used is the very same one that I used on my system to install  the dependencies (Though in my case, I already had the base SDL2 and freetype. I figured I'd leave them in just in case to be safe rather than sorry. Not like it'll affect anything if they're already installed anyway, haha)