### PR TITLE
Fix BN launching on Windows

### DIFF
--- a/scripts/Catapult.gd
+++ b/scripts/Catapult.gd
@@ -435,10 +435,14 @@ func _start_game(world := "") -> void:
 				params.append_array(["--world", world])
 			OS.execute(Paths.game_dir.plus_file("cataclysm-launcher"), params, false)
 		"Windows":
+			var game = Settings.read("game")
 			var world_str := ""
 			if world != "":
 				world_str = "--world \"%s\"" % world
-			var command = "cd /d %s && start cataclysm-tiles.exe --userdir \"%s/\" %s" % [Paths.game_dir, Paths.userdata, world_str]
+			if game == "bn":
+				var command = "cd /d %s && start cataclysm-bn.exe --userdir \"%s/\" %s" % [Paths.game_dir, Paths.userdata, world_str]
+			else:
+				var command = "cd /d %s && start cataclysm-tiles.exe --userdir \"%s/\" %s" % [Paths.game_dir, Paths.userdata, world_str]
 			OS.execute("cmd", ["/C", command], false)
 		_:
 			return

--- a/scripts/Catapult.gd
+++ b/scripts/Catapult.gd
@@ -440,7 +440,7 @@ func _start_game(world := "") -> void:
 			if world != "":
 				world_str = "--world \"%s\"" % world
 			if game == "bn":
-				var command = "cd /d %s && start cataclysm-bn.exe --userdir \"%s/\" %s" % [Paths.game_dir, Paths.userdata, world_str]
+				var command = "cd /d %s && start cataclysm-bn-tiles.exe --userdir \"%s/\" %s" % [Paths.game_dir, Paths.userdata, world_str]
 			else:
 				var command = "cd /d %s && start cataclysm-tiles.exe --userdir \"%s/\" %s" % [Paths.game_dir, Paths.userdata, world_str]
 			OS.execute("cmd", ["/C", command], false)


### PR DESCRIPTION
Hello!
Over at Bright Nights, we recently changed the name of the executable used to run the game. Thus, Catapult currently fails to launch the most recent release of BN when on Windows (Linux doesn't have this problem because we kept cataclysm-launcher the same). This PR should hopefully fix this issue

closes #163