### PR TITLE
Added flatpak definition file

### DIFF
--- a/flatpak/catapult.yaml
+++ b/flatpak/catapult.yaml
@@ -1,0 +1,23 @@
+id: "com.github.qrrk.catapult"
+runtime: "org.freedesktop.Platform"
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+command: catapult
+finish-args:
+  - --socket=pulseaudio
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  - --share=network
+
+modules:
+  - name: catapult
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 catapult /app/bin/catapult
+    sources:
+      - type: file
+        url: "https://github.com/qrrk/Catapult/releases/download/24.07a/catapult-linux-x64-24.07a"
+        sha256: "5894dc413a249da9ee2437c830ff34cd1cd6daf1fffef3d31f4e5c9b2968eea7"
+        dest-filename: "catapult"


### PR DESCRIPTION
This PR adds flatpak definition file. This could be exported to flathub so it would be easy to use catapult on SteamDeck. Currenlty the only way to use Catapult  on SteamDeck is using proton because the CDDA dependencies are not available in the system and it's not straightforward to install them because of read only root partition.

I've tested this on my pc using:

`flatpak-builder --force-clean build-dir catapult.yaml `

and then:

`flatpak-builder --run build-dir catapult.yaml catapult` 

I've loaded latest experimental and downloaded a soundpack and then started a game with it, all worked flawlessly.

What do you think? Would it be possible to upload this to flathub?