### PR TITLE
Update Bright Nights modpack to new maintainer Zlor's repo

### DIFF
--- a/scripts/ModManager.gd
+++ b/scripts/ModManager.gd
@@ -24,8 +24,8 @@ const _MODPACKS = {
 	},
 	"kenan-bn": {
 		"name": "BN Kenan Modpack",
-		"url": "https://github.com/Kenan2000/Bright-Nights-Kenan-Mod-Pack/archive/refs/heads/master.zip",
-		"filename": "Bright-Nights-Kenan-Mod-Pack-master.zip",
+		"url": "https://github.com/Zlorthishen/BrightNights-Structured-Kenan-Modpack/archive/refs/heads/master.zip",
+		"filename": "BrightNights-Structured-Kenan-Modpack-master.zip",
 		"internal_paths": [
 			"BrightNights-Structured-Kenan-Modpack-master/Kenan-BrightNights-Structured-Modpack/High-Maintenance-Huge-Mods",
 			"BrightNights-Structured-Kenan-Modpack-master/Kenan-BrightNights-Structured-Modpack/Medium-Maintenance-Small-Mods",


### PR DESCRIPTION
Kenan2000 is [no longer maintaining](https://github.com/Kenan2000/BrightNights-Structured-Kenan-Modpack/blob/master/README.md) his modpacks for DDA and BN, but in the case of BN, Zlorthishen has taken up maintaining the pack in a [new fork](https://github.com/Zlorthishen/BrightNights-Structured-Kenan-Modpack/tree/master). I haven't really been able to find an "official" announcement that I could link here as of yet, but the `#zlor-mods` channel on the Bright Nights Discord server recognizes Zlor as the new maintainer.

This PR redirects Catapult to Zlor's new fork when retrieving the new fork when Bright Nights is selected.

For testing, I imported the project into Godot and was able to run the project and get the new version of the modpack when running from within Godot.

![image](https://github.com/user-attachments/assets/a5ecb46a-6f19-4054-a561-e3357c249b4f)

I'm honestly not sure why the ` Archive extraction command exited with an error (exit code: 50)` line appears, though it also does that when launching in Godot without my changes present, and the files all seem to extract properly anyway, and I was able to successfully start a game with a number of the mods from the pack turned on.

I tried to export the project based on the instructions in [CONTRIBUTING.md](https://github.com/qrrk/Catapult/blob/master/CONTRIBUTING.md), but was running into issues with all of the text being missing. If I can figure out the exporting, I can get a screenshot from there and see if the archive extraction error is still there. Beyond that, let me know if there are any other updates to be made!