### PR TITLE
Experimental release naming conventions changed

### DIFF
--- a/scripts/ReleaseManager.gd
+++ b/scripts/ReleaseManager.gd
@@ -21,11 +21,11 @@ const _RELEASE_URLS = {
 const _ASSET_FILTERS = {
 	"dda-experimental-linux": {
 		"field": "name",
-		"substring": "cdda-linux-tiles-x64",
+		"substring": "cdda-linux-with-graphics-and-sounds-x64",
 	},
 	"dda-experimental-win": {
 		"field": "name",
-		"substring": "cdda-windows-tiles-x64",
+		"substring": "cdda-windows-with-graphics-and-sounds-x64",
 	},
 	"bn-experimental-linux": {
 		"field": "name",


### PR DESCRIPTION
fix #180

change cdda-*-tiles-x64 to cdda-*-with-graphics-and-sounds-x64

It was quite a simple fix. I guess I forgot something. But it works on my machine ;)

