### PR TITLE
[WIP] Added Cataclysm: The Last Generation as a new Fork

### DIFF
--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -84,7 +84,7 @@ margin_bottom = 24.0
 hint_tooltip = "tooltip_game"
 size_flags_horizontal = 3
 text = "Cataclysm: Dark Days Ahead"
-items = [ "Cataclysm: Dark Days Ahead", null, false, 0, null, "Cataclysm: Bright Nights", null, false, 1, null, "Cataclysm: Era Of Decay", null, false, 2, null, "Cataclysm: There Is Still Hope", null, false, 3, null ]
+items = [ "Cataclysm: Dark Days Ahead", null, false, 0, null, "Cataclysm: Bright Nights", null, false, 1, null, "Cataclysm: Era Of Decay", null, false, 2, null, "Cataclysm: There Is Still Hope", null, false, 3, null, "Cataclysm: The Last Generation", null, false, 4, null ]
 selected = 0
 
 [node name="GameInfo" type="HBoxContainer" parent="Main"]
@@ -1360,6 +1360,8 @@ __meta__ = {
 
 [node name="HTTPRequest_TISH" type="HTTPRequest" parent="Releases"]
 
+[node name="HTTPRequest_TLG" type="HTTPRequest" parent="Releases"]
+
 [node name="ReleaseInstaller" type="Node" parent="."]
 script = ExtResource( 9 )
 __meta__ = {
@@ -1478,6 +1480,7 @@ __meta__ = {
 [connection signal="request_completed" from="Releases/HTTPRequest_BN" to="Releases" method="_on_request_completed_bn"]
 [connection signal="request_completed" from="Releases/HTTPRequest_EOD" to="Releases" method="_on_request_completed_eod"]
 [connection signal="request_completed" from="Releases/HTTPRequest_TISH" to="Releases" method="_on_request_completed_tish"]
+[connection signal="request_completed" from="Releases/HTTPRequest_TLG" to="Releases" method="_on_request_completed_tlg"]
 [connection signal="operation_finished" from="ReleaseInstaller" to="." method="_on_ReleaseInstaller_operation_finished"]
 [connection signal="operation_started" from="ReleaseInstaller" to="." method="_on_ReleaseInstaller_operation_started"]
 [connection signal="mod_deletion_finished" from="Mods" to="." method="_on_mod_operation_finished"]

--- a/scripts/Catapult.gd
+++ b/scripts/Catapult.gd
@@ -28,6 +28,7 @@ onready var _lst_installs = $Main/Tabs/Game/GameInstalls/HBox/InstallsList
 onready var _btn_make_active = $Main/Tabs/Game/GameInstalls/HBox/VBox/btnMakeActive
 onready var _btn_delete = $Main/Tabs/Game/GameInstalls/HBox/VBox/btnDelete
 onready var _panel_installs = $Main/Tabs/Game/GameInstalls
+onready var _btn_get_kenan = $Main/Tabs/Mods/HBox/Available/BtnDownloadKenan
 
 var _disable_savestate := {}
 var _installs := {}
@@ -102,6 +103,8 @@ func assign_localized_text() -> void:
 		_game_desc.bbcode_text = tr("desc_eod")
 	elif game == "tish":
 		_game_desc.bbcode_text = tr("desc_tish")
+	elif game == "tlg":
+		_game_desc.bbcode_text = tr("desc_tlg")
 
 
 func load_ui_theme(theme_file: String) -> void:
@@ -191,6 +194,9 @@ func _on_GamesList_item_selected(index: int) -> void:
 		3:
 			Settings.store("game", "tish")
 			_game_desc.bbcode_text = tr("desc_tish")
+		4:
+			Settings.store("game", "tlg")
+			_game_desc.bbcode_text = tr("desc_tlg")
 	
 	_tabs.current_tab = 0
 	apply_game_choice()
@@ -379,16 +385,25 @@ func apply_game_choice() -> void:
 	if (game == "dda") or (game == "bn"):
 		_rbtn_exper.disabled = false
 		_rbtn_stable.disabled = false
+		# Thes Forks do have the Kenan Modpack
+		_btn_get_kenan.disabled = false
+		_btn_get_kenan.hint_tooltip = tr("tooltip_get_kenan_pack")
 		if channel == "stable":
 			_rbtn_stable.pressed = true
 			_btn_refresh.disabled = true
 		else:
 			_btn_refresh.disabled = false
-	elif (game == "eod") or (game == "tish"):
+	elif game in ["eod", "tish", "tlg"]:
+		# These Forks do not have a stable channel
 		_rbtn_exper.pressed = true
 		_rbtn_exper.disabled = true
 		_rbtn_stable.disabled = true
 		_btn_refresh.disabled = false
+		# These Forks do not have the Kenan Modpack
+		_btn_get_kenan.disabled = true
+		_btn_get_kenan.hint_tooltip = tr("tooltip_no_kenan_pack")
+	
+		
 
 	match game:
 		"dda":
@@ -406,7 +421,11 @@ func apply_game_choice() -> void:
 		"tish":
 			_lst_games.select(3)
 			_game_desc.bbcode_text = tr("desc_tish")
-	
+			
+		"tlg":
+			_lst_games.select(4)
+			_game_desc.bbcode_text = tr("desc_tlg")
+
 	if len(_releases.releases[_get_release_key()]) == 0:
 		_releases.fetch(_get_release_key())
 	else:

--- a/scripts/ChangelogDialod.gd
+++ b/scripts/ChangelogDialod.gd
@@ -6,6 +6,7 @@ const _PR_URL = {
 	"bn": "https://api.github.com/search/issues?q=repo%3Acataclysmbnteam/Cataclysm-BN",
 	"eod": "https://api.github.com/search/issues?q=repo%3AAtomicFox556/Cataclysm-EOD",
 	"tish": "https://api.github.com/search/issues?q=repo%3ACataclysm-TISH-team/Cataclysm-TISH/",
+	"tlg":  "https://api.github.com/search/issues?q=repo%3ACataclysm-TLG/Cataclysm-TLG/",
 }
 
 onready var _pullRequests := $PullRequests
@@ -83,6 +84,8 @@ func process_pr_data(data):
 			game_title = "Cataclysm: Era of Decay"
 		"tish":
 			game_title = "Cataclysm: There Is Still Hope"
+		"tlg":
+			game_title = "Cataclysm: The Last Generation"
 		_:
 			game_title = "{BUG!!}"
 	

--- a/scripts/ModManager.gd
+++ b/scripts/ModManager.gd
@@ -259,6 +259,9 @@ func install_mods(mod_ids: Array) -> void:
 func retrieve_kenan_pack() -> void:
 	
 	var game = Settings.read("game")
+	if( !game == "dda" || !game == "bn" ):
+		Status.post(tr("msg_kenan_unavailable") % game.to_upper())
+		return
 	var pack = _MODPACKS["kenan-" + game]
 	
 	emit_signal("modpack_retrieval_started")

--- a/scripts/ReleaseManager.gd
+++ b/scripts/ReleaseManager.gd
@@ -16,6 +16,8 @@ const _RELEASE_URLS = {
 		"https://api.github.com/repos/AtomicFox556/Cataclysm-EOD/releases",
 	"tish-experimental":
 		"https://api.github.com/repos/Cataclysm-TISH-team/Cataclysm-TISH/releases",
+	"tlg-experimental":
+		"https://api.github.com/repos/Cataclysm-TLG/Cataclysm-TLG/releases",
 }
 
 const _ASSET_FILTERS = {
@@ -50,6 +52,14 @@ const _ASSET_FILTERS = {
 	"tish-experimental-win": {
 		"field": "name",
 		"substring": "tish-windows-tiles-x64",
+	},
+	"tlg-experimental-linux": {
+		"field": "name",
+		"substring": "ctlg-linux-tiles-x64",
+	},
+	"tlg-experimental-win": {
+		"field": "name",
+		"substring": "ctlg-windows-tiles-x64",
 	},
 }
 
@@ -265,10 +275,11 @@ var releases = {
 	"dda-experimental": [],
 	"bn-stable": [],
 	"bn-experimental": [],
-	"eod-stable": [],
+	#"eod-stable": [], Does not exist?
 	"eod-experimental": [],
-	"tish-stable": [],
+	#"tish-stable": [], Does not exist?
 	"tish-experimental": [],
+	"tlg-experimental":[],
 }
 
 
@@ -359,6 +370,19 @@ func _on_request_completed_tish(result: int, response_code: int,
 	
 	emit_signal("done_fetching_releases")
 
+func _on_request_completed_tlg(result: int, response_code: int,
+		headers: PoolStringArray, body: PoolByteArray) -> void:
+	
+	Status.post(tr("msg_http_request_info") %
+			[result, response_code, headers], Enums.MSG_DEBUG)
+	
+	if result:
+		Status.post(tr("msg_releases_request_failed"), Enums.MSG_WARN)
+	else:
+		_parse_builds(body, releases["tlg-experimental"], _ASSET_FILTERS["tlg-experimental-" + _platform])
+	
+	emit_signal("done_fetching_releases")
+
 func _parse_builds(data: PoolByteArray, write_to: Array, filter: Dictionary) -> void:
 	
 	var json = JSON.parse(data.get_string_from_utf8()).result
@@ -420,6 +444,8 @@ func fetch(release_key: String) -> void:
 		"tish-experimental":
 			Status.post(tr("msg_fetching_releases_tish"))
 			_request_releases($HTTPRequest_TISH, "tish-experimental")
+		"tlg-experimental":
+			Status.post(tr("msg_fetching_releases") % [release_key])
+			_request_releases($HTTPRequest_TLG, "tlg-experimental")
 		_:
-			Status.post(tr("msg_invalid_fetch_func_param") % release_key, Enums.MSG_ERROR)
-
+			Status.post((tr("msg_invalid_fetch_func_param") % [release_key] ), Enums.MSG_ERROR)

--- a/scripts/path_helper.gd
+++ b/scripts/path_helper.gd
@@ -41,7 +41,7 @@ func _get_installs_summary() -> Dictionary:
 	var result = {}
 	var d = Directory.new()
 	
-	for game in ["dda", "bn", "eod", "tish"]:
+	for game in ["dda", "bn", "eod", "tish", "tlg"]:
 		var installs = {}
 		var base_dir = Paths.own_dir.plus_file(game)
 		for subdir in FS.list_dir(base_dir):

--- a/scripts/settings_manager.gd
+++ b/scripts/settings_manager.gd
@@ -10,6 +10,7 @@ const _HARDCODED_DEFAULTS = {
 	"active_install_bn": "",
 	"active_install_eod": "",
 	"active_install_tish": "",
+	"active_install_tlg":"",
 	"update_current_when_installing": true,
 	"launcher_locale": "",
 	"launcher_theme": "Godot_3.res",

--- a/text/en/game_tab.csv
+++ b/text/en/game_tab.csv
@@ -24,7 +24,7 @@
 "tooltip_experimental","Experimental release channel."
 "tooltip_builds","Choose which release of the game to install or update to."
 "tooltip_refresh","Re-retrieve the list of available game releases\nfrom GitHub (only for experimental releases)."
-"tooltip_install","Install selected game release (DDA and BN\nare managed separately and can co-exist)."
+"tooltip_install","Install selected game release (Different forks\n are managed separately and can co-exist)."
 "tooltip_update","If checked, the game install currently set as active\nwill be replaced with the version selected above.\nOtherwise, the selected build will be a new,\nseparate install of the game."
 "tooltip_game_dir","Open game installation directory (contains\ngame executable and built-in game content)."
 "tooltip_user_dir","Open user data directory (contains saves, \ngame configuration, user mods, sound, etc.)"

--- a/text/en/general.csv
+++ b/text/en/general.csv
@@ -17,6 +17,7 @@
 "desc_bn","[b]Cataclysm: Bright Nights[/b]. Reject pedantry, embrace [color=#ff3300]!!fun!![/color]. This fork takes the game back to its sci-fi roguelike roots and reverts many controversial changes by the DDA team (pockets, proficiencies, freezing, and [color=#3b93f7][url=https://docs.cataclysmbn.org/en/game/changelog/]more[/url][/color]). Special attention is paid to combat, game balance and pacing."
 "desc_eod","[b]Cataclysm: Era of Decay[/b] is a fork of DDA, primarily aiming to have as much player-accessible configurability as practically possible, without completely removing any of the original game's features or content and leaving the game realistic with default settings. Have fun in the way that [color=#ff3300]you[/color] want."
 "desc_tish","[b]Cataclysm: There Is Still Hope[/b] is a fork of DDA with a focus on the game being interesting above all else, rejecting the dichotomies of ''realism or fun'' and ''verisimilitude or fun''."
+"desc_tlg","[b]Cataclysm: The Last Generation[/b]s primary aim is to preserve Cataclysm's depth and respect for plausibility while refining what it has always done best as a game, foregrounding character progression and immersive life sim elements in a world that will put your survival skills to the test. "
 ,
 "tab_game","Game"
 "tab_mods","Mods"

--- a/text/en/mod_manager.csv
+++ b/text/en/mod_manager.csv
@@ -8,6 +8,7 @@
 "msg_mod_installed","Installed %s"
 "msg_installing_n_mods","Installing %s mods..."
 "msg_getting_kenan_pack","Retrieving Kenan Modpack for %s..."
+"msg_kenan_unavailable", "The Kenan Modpack is not available for %s.."
 "msg_wiping_mod_repo","Wiping the repository..."
 "msg_unpacking_kenan_mods","Adding mods from the pack to repository..."
 "msg_unpacking_archived_mods","Adding archived mods to repository..."

--- a/text/en/mods_tab.csv
+++ b/text/en/mods_tab.csv
@@ -24,6 +24,7 @@
 "tooltip_add_sel_mods","Add selected mods to your game installation."
 "tooltip_add_all_mods","Add all listed mods to your game installation."
 "tooltip_get_kenan_pack","Download Kenan Modpack and add its mods\nto the local repository."
+"tooltip_no_kenan_pack","The Kenan Modpack is not available\nfor the active fork."
 ,
 "msg_one_mod_is_stock","One of the selected mods is stock and cannot be deleted."
 "msg_n_mods_are_stock","%s of the selected mods are stock and cannot be deleted."

--- a/text/en/release_manager.csv
+++ b/text/en/release_manager.csv
@@ -8,4 +8,5 @@
 "msg_fetching_releases_bn","Fetching releases for BN Experimental..."
 "msg_fetching_releases_eod","Fetching releases for EOD Experimental..."
 "msg_fetching_releases_tish","Fetching releases for TISH Experimental..."
+"msg_fetching_releases","Fetching releases for \""%s""..."
 "msg_invalid_fetch_func_param","ReleaseManager.fetch() was passed %s"


### PR DESCRIPTION
## Summary 
This PR adds support for Cataclysm: The Last Generation (TLG) to the Catapult Launcher, alongside existing Cataclysm forks to solve #191. 
TLG has a running CI/CD now and pulls the releases from https://github.com/Cataclysm-TLG/Cataclysm-TLG/releases.

It implements the new fork the same way as https://github.com/qrrk/Catapult/commit/c8b24b8010cb8451aadb2c6081c0e288d0d0d77f.  This solution is quite ugly and it probably needs a refactor but it works for now.

I also fixed a crash bug caused by trying to download the Kenan Modpack  when it does not exist for the current active fork. 

###Todo:
- [ ] Correct / Better Descripion
- [ ] Localization for other languages 
- [ ] Test on Windows 
- [ ] Test Mods / Backups