### PR TITLE
Add Cataclysm: The Last Generation (TLG) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ git_api.gdns
 
 # vscode
 .vscode
+
+# Godot Engine
+builds/
+exports/

--- a/icons/appicon.svg.import
+++ b/icons/appicon.svg.import
@@ -28,6 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/icons/help.svg.import
+++ b/icons/help.svg.import
@@ -28,6 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/icons/info.svg.import
+++ b/icons/info.svg.import
@@ -28,6 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/icons/placeholder.svg.import
+++ b/icons/placeholder.svg.import
@@ -28,6 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/icons/transparent.png.import
+++ b/icons/transparent.png.import
@@ -28,6 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/project.godot
+++ b/project.godot
@@ -45,7 +45,7 @@ _global_script_class_icons={
 [application]
 
 config/name="Catapult"
-config/description="A cross-platform launcher for Cataclysm: DDA and BN"
+config/description="A cross-platform launcher for Cataclysm: DDA, BN and others"
 run/main_scene="res://scenes/Catapult.tscn"
 run/low_processor_mode=true
 boot_splash/image="res://icons/transparent.png"

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -84,8 +84,8 @@ margin_bottom = 24.0
 hint_tooltip = "tooltip_game"
 size_flags_horizontal = 3
 text = "Cataclysm: Dark Days Ahead"
-items = [ "Cataclysm: Dark Days Ahead", null, false, 0, null, "Cataclysm: Bright Nights", null, false, 1, null, "Cataclysm: Era Of Decay", null, false, 2, null, "Cataclysm: There Is Still Hope", null, false, 3, null ]
-selected = 0
+items = [ "Cataclysm: Dark Days Ahead", null, false, 0, null, "Cataclysm: Bright Nights", null, false, 1, null, "Cataclysm: Era Of Decay", null, false, 2, null, "Cataclysm: There Is Still Hope", null, false, 3, null, "Cataclysm: The Last Generation", null, false, 4, null ]
+selected = 0 
 
 [node name="GameInfo" type="HBoxContainer" parent="Main"]
 margin_top = 28.0
@@ -1360,6 +1360,8 @@ __meta__ = {
 
 [node name="HTTPRequest_TISH" type="HTTPRequest" parent="Releases"]
 
+[node name="HTTPRequest_TLG" type="HTTPRequest" parent="Releases"]
+
 [node name="ReleaseInstaller" type="Node" parent="."]
 script = ExtResource( 9 )
 __meta__ = {
@@ -1478,6 +1480,7 @@ __meta__ = {
 [connection signal="request_completed" from="Releases/HTTPRequest_BN" to="Releases" method="_on_request_completed_bn"]
 [connection signal="request_completed" from="Releases/HTTPRequest_EOD" to="Releases" method="_on_request_completed_eod"]
 [connection signal="request_completed" from="Releases/HTTPRequest_TISH" to="Releases" method="_on_request_completed_tish"]
+[connection signal="request_completed" from="Releases/HTTPRequest_TLG" to="Releases" method="_on_request_completed_tlg"]
 [connection signal="operation_finished" from="ReleaseInstaller" to="." method="_on_ReleaseInstaller_operation_finished"]
 [connection signal="operation_started" from="ReleaseInstaller" to="." method="_on_ReleaseInstaller_operation_started"]
 [connection signal="mod_deletion_finished" from="Mods" to="." method="_on_mod_operation_finished"]

--- a/scenes/Catapult.tscn
+++ b/scenes/Catapult.tscn
@@ -85,7 +85,7 @@ hint_tooltip = "tooltip_game"
 size_flags_horizontal = 3
 text = "Cataclysm: Dark Days Ahead"
 items = [ "Cataclysm: Dark Days Ahead", null, false, 0, null, "Cataclysm: Bright Nights", null, false, 1, null, "Cataclysm: Era Of Decay", null, false, 2, null, "Cataclysm: There Is Still Hope", null, false, 3, null, "Cataclysm: The Last Generation", null, false, 4, null ]
-selected = 0 
+selected = 0
 
 [node name="GameInfo" type="HBoxContainer" parent="Main"]
 margin_top = 28.0

--- a/scenes/ChangelogDialog.tscn
+++ b/scenes/ChangelogDialog.tscn
@@ -75,7 +75,7 @@ __meta__ = {
 }
 
 [node name="PullRequests" type="HTTPRequest" parent="."]
-timeout = 20
+timeout = 20.0
 
 [connection signal="meta_clicked" from="Panel/Margin/VBox/ChangelogText" to="." method="_on_ChangelogText_meta_clicked"]
 [connection signal="pressed" from="Panel/Margin/VBox/BtnCloseChangelog" to="." method="_on_BtnCloseChangelog_pressed"]

--- a/scripts/Catapult.gd
+++ b/scripts/Catapult.gd
@@ -390,7 +390,7 @@ func apply_game_choice() -> void:
 			_btn_refresh.disabled = true
 		else:
 			_btn_refresh.disabled = false
-	elif (game == "eod") or (game == "tish"):
+	elif (game == "eod") or (game == "tish") or (game == "tlg"):
 		_rbtn_exper.pressed = true
 		_rbtn_exper.disabled = true
 		_rbtn_stable.disabled = true

--- a/scripts/Catapult.gd
+++ b/scripts/Catapult.gd
@@ -102,6 +102,8 @@ func assign_localized_text() -> void:
 		_game_desc.bbcode_text = tr("desc_eod")
 	elif game == "tish":
 		_game_desc.bbcode_text = tr("desc_tish")
+	elif game == "tlg":
+		_game_desc.bbcode_text = tr("desc_tlg)
 
 
 func load_ui_theme(theme_file: String) -> void:
@@ -191,6 +193,10 @@ func _on_GamesList_item_selected(index: int) -> void:
 		3:
 			Settings.store("game", "tish")
 			_game_desc.bbcode_text = tr("desc_tish")
+		4:	
+			Settings.store("game", "tlg")
+			_game_desc.bbcode_text = tr("desc_tlg")
+	
 	
 	_tabs.current_tab = 0
 	apply_game_choice()
@@ -406,7 +412,11 @@ func apply_game_choice() -> void:
 		"tish":
 			_lst_games.select(3)
 			_game_desc.bbcode_text = tr("desc_tish")
-	
+		
+		"tlg":
+			_lst_games.select(4)
+			_game_desc.bbcode_text = tr("desc_tlg")
+
 	if len(_releases.releases[_get_release_key()]) == 0:
 		_releases.fetch(_get_release_key())
 	else:

--- a/scripts/Catapult.gd
+++ b/scripts/Catapult.gd
@@ -103,7 +103,7 @@ func assign_localized_text() -> void:
 	elif game == "tish":
 		_game_desc.bbcode_text = tr("desc_tish")
 	elif game == "tlg":
-		_game_desc.bbcode_text = tr("desc_tlg)
+		_game_desc.bbcode_text = tr("desc_tlg")
 
 
 func load_ui_theme(theme_file: String) -> void:

--- a/scripts/ChangelogDialod.gd
+++ b/scripts/ChangelogDialod.gd
@@ -6,6 +6,7 @@ const _PR_URL = {
 	"bn": "https://api.github.com/search/issues?q=repo%3Acataclysmbnteam/Cataclysm-BN",
 	"eod": "https://api.github.com/search/issues?q=repo%3AAtomicFox556/Cataclysm-EOD",
 	"tish": "https://api.github.com/search/issues?q=repo%3ACataclysm-TISH-team/Cataclysm-TISH/",
+	"tlg": "https://api.github.com/search/issues?q=repo%3ACataclysm-TLG/Cataclysm-TLG/releases",
 }
 
 onready var _pullRequests := $PullRequests
@@ -83,8 +84,10 @@ func process_pr_data(data):
 			game_title = "Cataclysm: Era of Decay"
 		"tish":
 			game_title = "Cataclysm: There Is Still Hope"
+		"tlg":
+		game_title = "Cataclysm: The Last Generation"
 		_:
-			game_title = "{BUG!!}"
+		game_title = "{BUG!!}" 
 	
 	var r_val = tr("str_changelog_intro") % [Settings.read("num_prs_to_request"), game_title]
 	

--- a/scripts/ChangelogDialod.gd
+++ b/scripts/ChangelogDialod.gd
@@ -85,9 +85,9 @@ func process_pr_data(data):
 		"tish":
 			game_title = "Cataclysm: There Is Still Hope"
 		"tlg":
-		game_title = "Cataclysm: The Last Generation"
+			game_title = "Cataclysm: The Last Generation"
 		_:
-		game_title = "{BUG!!}" 
+			game_title = "{BUG!!}" 
 	
 	var r_val = tr("str_changelog_intro") % [Settings.read("num_prs_to_request"), game_title]
 	

--- a/scripts/ReleaseManager.gd
+++ b/scripts/ReleaseManager.gd
@@ -16,6 +16,8 @@ const _RELEASE_URLS = {
 		"https://api.github.com/repos/AtomicFox556/Cataclysm-EOD/releases",
 	"tish-experimental":
 		"https://api.github.com/repos/Cataclysm-TISH-team/Cataclysm-TISH/releases",
+	"tlg-experimental":
+		"https://api.github.com/repos/Cataclysm-TLG/Cataclysm-TLG/releases",
 }
 
 const _ASSET_FILTERS = {
@@ -50,6 +52,14 @@ const _ASSET_FILTERS = {
 	"tish-experimental-win": {
 		"field": "name",
 		"substring": "tish-windows-tiles-x64",
+	},
+	"tlg-experimental-linux": {
+		"field": "name",
+		"substring": "ctlg-linux-tiles-x64",
+	},
+	"tlg-experimental-win": {
+		"field": "name",
+		"substring": "ctlg-windows-tiles-x64",
 	},
 }
 
@@ -269,6 +279,8 @@ var releases = {
 	"eod-experimental": [],
 	"tish-stable": [],
 	"tish-experimental": [],
+	"tlg-stable": [],
+	"tlg-experimental": [],
 }
 
 
@@ -359,6 +371,19 @@ func _on_request_completed_tish(result: int, response_code: int,
 	
 	emit_signal("done_fetching_releases")
 
+func _on_request_completed_tlg(result: int, response_code: int,
+		headers: PoolStringArray, body: PoolByteArray) -> void:
+	
+	Status.post(tr("msg_http_request_info") %
+			[result, response_code, headers], Enums.MSG_DEBUG)
+	
+	if result:
+		Status.post(tr("msg_releases_request_failed"), Enums.MSG_WARN)
+	else:
+		_parse_builds(body, releases["tlg-experimental"], _ASSET_FILTERS["tlg-experimental-" + _platform])
+	
+	emit_signal("done_fetching_releases")
+
 func _parse_builds(data: PoolByteArray, write_to: Array, filter: Dictionary) -> void:
 	
 	var json = JSON.parse(data.get_string_from_utf8()).result
@@ -420,6 +445,8 @@ func fetch(release_key: String) -> void:
 		"tish-experimental":
 			Status.post(tr("msg_fetching_releases_tish"))
 			_request_releases($HTTPRequest_TISH, "tish-experimental")
+		"tlg-experimental":
+			Status.post(tr("msg_fetching_releases_tlg"))
+			_request_releases($HTTPRequest_TLG, "tlg-experimental")
 		_:
-			Status.post(tr("msg_invalid_fetch_func_param") % release_key, Enums.MSG_ERROR)
-
+			Status.post(tr("msg_invalid_fetch_func_param") % release_key, Enums.MSG_ERROR) 

--- a/scripts/path_helper.gd
+++ b/scripts/path_helper.gd
@@ -41,7 +41,7 @@ func _get_installs_summary() -> Dictionary:
 	var result = {}
 	var d = Directory.new()
 	
-	for game in ["dda", "bn", "eod", "tish"]:
+	for game in ["dda", "bn", "eod", "tish", "tlg"]:
 		var installs = {}
 		var base_dir = Paths.own_dir.plus_file(game)
 		for subdir in FS.list_dir(base_dir):
@@ -51,7 +51,7 @@ func _get_installs_summary() -> Dictionary:
 				installs[info["name"]] = base_dir.plus_file(subdir)
 		if not installs.empty():
 			result[game] = installs
-	
+			
 	# Ensure that some installation of the game is set as active
 	var game = Settings.read("game")
 	var active_name = Settings.read("active_install_" + game)

--- a/scripts/settings_manager.gd
+++ b/scripts/settings_manager.gd
@@ -10,6 +10,7 @@ const _HARDCODED_DEFAULTS = {
 	"active_install_bn": "",
 	"active_install_eod": "",
 	"active_install_tish": "",
+	"active_install_tlg": "", 
 	"update_current_when_installing": true,
 	"launcher_locale": "",
 	"launcher_theme": "Godot_3.res",

--- a/text/cs/general.csv
+++ b/text/cs/general.csv
@@ -16,6 +16,7 @@
 "desc_bn","[b]Cataclysm: Bright Nights[/b]. Odmítněte puntičkářství, přijměte [color=#ff3300]!!zábavu!![/color]. Tato odnož bere hru zpět do jejích sci-fi roguelike kořenů a vrací zpět spoustu kontroverzních změn od týmu DDA (kapsy, dovednosti, mražení, a [color=#3b93f7][url=https://docs.cataclysmbn.org/en/game/changelog/]více[/url][/color]). Zvláštní pozornost je dávána boji, balancování a tempu hry."
 "desc_eod","[b]Cataclysm: Dark Days Ahead[/b] je vidlice DDA, jejímž cílem je především mít co nejvíce konfigurovatelnosti přístupné pro hráče, jak je to prakticky možné, aniž by došlo k úplnému odstranění jakýchkoli funkcí nebo obsahu původní hry a ponechání hry Realistické s výchozím nastavením. Bavte se způsobem, který [color=#ff3300]vy[/color] chcete."
 "desc_tish","[b]Cataclysm: There Is Still Hope[/b] je vidlička DDA se zaměřením na hru, která je zajímavá především, odmítá dichotomie ''realismu nebo zábavy'' a ''věrohodnosti nebo zábavy''."
+"desc_tlg","[b]Cataclysm: The Last Generation[/b] je odnož DDA, která se zaměřuje na přežití v postapokalyptickém světě. Hra má nový systém výzev, nové věci, nové vozidla a mnoho dalších novinek."
 ,
 "tab_game","Hra"
 "tab_mods","Mody"

--- a/text/cs/release_manager.csv
+++ b/text/cs/release_manager.csv
@@ -6,4 +6,5 @@
 "msg_got_n_releases","Získáno %s vydání."
 "msg_fetching_releases_dda","Získávám vydání pro DDA Experimental..."
 "msg_fetching_releases_bn","Získávám vydání pro BN Experimental..."
+"msg_fetching_releases_tlg","Získávám vydání pro TLG Experimental..."
 "msg_invalid_fetch_func_param","ReleaseManager.fetch() dostal %s"

--- a/text/en/general.csv
+++ b/text/en/general.csv
@@ -17,6 +17,7 @@
 "desc_bn","[b]Cataclysm: Bright Nights[/b]. Reject pedantry, embrace [color=#ff3300]!!fun!![/color]. This fork takes the game back to its sci-fi roguelike roots and reverts many controversial changes by the DDA team (pockets, proficiencies, freezing, and [color=#3b93f7][url=https://docs.cataclysmbn.org/en/game/changelog/]more[/url][/color]). Special attention is paid to combat, game balance and pacing."
 "desc_eod","[b]Cataclysm: Era of Decay[/b] is a fork of DDA, primarily aiming to have as much player-accessible configurability as practically possible, without completely removing any of the original game's features or content and leaving the game realistic with default settings. Have fun in the way that [color=#ff3300]you[/color] want."
 "desc_tish","[b]Cataclysm: There Is Still Hope[/b] is a fork of DDA with a focus on the game being interesting above all else, rejecting the dichotomies of ''realism or fun'' and ''verisimilitude or fun''."
+"desc_tlg","[b]Cataclysm: The Last Generation[/b] is a fork focusing on unique gameplay experiences in the Cataclysm universe, bringing new mechanics and challenges to the post-apocalyptic world." 
 ,
 "tab_game","Game"
 "tab_mods","Mods"

--- a/text/en/release_manager.csv
+++ b/text/en/release_manager.csv
@@ -8,4 +8,5 @@
 "msg_fetching_releases_bn","Fetching releases for BN Experimental..."
 "msg_fetching_releases_eod","Fetching releases for EOD Experimental..."
 "msg_fetching_releases_tish","Fetching releases for TISH Experimental..."
+"msg_fetching_releases_tlg","Fetching releases for TLG Experimental..."
 "msg_invalid_fetch_func_param","ReleaseManager.fetch() was passed %s"

--- a/text/es/general.csv
+++ b/text/es/general.csv
@@ -17,6 +17,7 @@
 "desc_bn","[b]Cataclysm: Bright Nights[/b]. Rechaza la pedantería, abraza la [color=#ff3300]!!diversión!![/color]. Esta ramificación vuelve el juego a sus raíces sci-fi y revierte muchos cambios controversiales hechos por el equipo de  DDA (bolsillos, habilidades, congelamiento, y [color=#3b93f7][url=https://docs.cataclysmbn.org/en/game/changelog/]más[/url][/color]). Se le prestó mas atención al combate, balance y ritmo del juego."
 "desc_eod","[b]Cataclysm: Era of Decay[/b] es una bifurcación de DDA, cuyo objetivo principal es tener tanta capacidad de configuración accesible para el jugador como sea posible, sin eliminar por completo ninguna de las características o el contenido del juego original y dejar el juego realista con la configuración predeterminada. Diviértete de la manera que [color=#ff3300]quieras[/color]."
 "desc_tish","[b]Cataclysm: There Is Still Hope[/b] es una bifurcación de DDA con un enfoque en que el juego sea interesante por encima de todo, rechazando las dicotomías de ''realismo o diversión'' y ''verosimilitud o diversión''."
+"desc_tlg","[b]Cataclysm: The Last Generation[/b] es una bifurcación de DDA con un enfoque en experiencias de juego únicas en el universo de Cataclysm, llevando nuevos mecanismos y desafíos al mundo postapocalíptico."
 ,
 "tab_game","Juego"
 "tab_mods","Mods"

--- a/text/fr/general.csv
+++ b/text/fr/general.csv
@@ -17,6 +17,7 @@
 "desc_bn","[b]Cataclysm: Bright Nights[/b]. Rejetez le pédantisme, adoptez le [color=#ff3300]!!fun!![/color]. Ce fork ramène le jeu à ses racines de science-fiction roguelike et annule de nombreux changements controversés par l'équipe DDA (poches, compétences, gel et [color=#3b93f7][url=https://docs.cataclysmbn.org/en/game/changelog/]plus[/url][/color]). Une attention particulière est portée au combat, à l'équilibre du jeu et au rythme. "
 "desc_eod","[b]Cataclysm: Era of Decay[/b] est un fork de DDA, visant principalement à avoir autant de configurabilité accessible aux joueurs que possible, sans supprimer complètement les fonctionnalités ou le contenu du jeu original et en laissant le jeu réaliste avec les paramètres par défaut. Amusez-vous de la manière que [color=#ff3300]vous[/color] voulez."
 "desc_tish","[b]Cataclysm: There Is Still Hope[/b] est un fork de DDA qui met l'accent sur le fait que le jeu est intéressant par-dessus tout, rejetant les dichotomies de ''réalisme ou amusement'' et de ''vraisemblance ou amusement''."
+"desc_tlg","[b]Cataclysm: The Last Generation[/b] est un fork qui se concentre sur des expériences de jeu uniques dans l'univers de Cataclysm, apportant de nouveaux mécanismes et défis au monde post-apocalyptique."
 ,
 "tab_game","Jeu"
 "tab_mods","Mods"

--- a/text/zh/backup_manager.csv.import
+++ b/text/zh/backup_manager.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/backup_manager.zh.translation" ]
+files=[ "res://text/zh/backup_manager.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/backup_manager.csv"
-dest_files=[ "res://text/zh/backup_manager.zh.translation" ]
+dest_files=[ "res://text/zh/backup_manager.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/backups_tab.csv.import
+++ b/text/zh/backups_tab.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/backups_tab.zh.translation" ]
+files=[ "res://text/zh/backups_tab.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/backups_tab.csv"
-dest_files=[ "res://text/zh/backups_tab.zh.translation" ]
+dest_files=[ "res://text/zh/backups_tab.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/changelog_dialog.csv.import
+++ b/text/zh/changelog_dialog.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/changelog_dialog.zh.translation" ]
+files=[ "res://text/zh/changelog_dialog.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/changelog_dialog.csv"
-dest_files=[ "res://text/zh/changelog_dialog.zh.translation" ]
+dest_files=[ "res://text/zh/changelog_dialog.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/dialog_buttons.csv.import
+++ b/text/zh/dialog_buttons.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/dialog_buttons.zh.translation" ]
+files=[ "res://text/zh/dialog_buttons.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/dialog_buttons.csv"
-dest_files=[ "res://text/zh/dialog_buttons.zh.translation" ]
+dest_files=[ "res://text/zh/dialog_buttons.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/download_manager.csv.import
+++ b/text/zh/download_manager.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/download_manager.zh.translation" ]
+files=[ "res://text/zh/download_manager.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/download_manager.csv"
-dest_files=[ "res://text/zh/download_manager.zh.translation" ]
+dest_files=[ "res://text/zh/download_manager.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/easter_egg.csv.import
+++ b/text/zh/easter_egg.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/easter_egg.zh.translation" ]
+files=[ "res://text/zh/easter_egg.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/easter_egg.csv"
-dest_files=[ "res://text/zh/easter_egg.zh.translation" ]
+dest_files=[ "res://text/zh/easter_egg.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/filesystem_helper.csv.import
+++ b/text/zh/filesystem_helper.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/filesystem_helper.zh.translation" ]
+files=[ "res://text/zh/filesystem_helper.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/filesystem_helper.csv"
-dest_files=[ "res://text/zh/filesystem_helper.zh.translation" ]
+dest_files=[ "res://text/zh/filesystem_helper.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/font_help_dialog.csv.import
+++ b/text/zh/font_help_dialog.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/font_help_dialog.zh.translation" ]
+files=[ "res://text/zh/font_help_dialog.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/font_help_dialog.csv"
-dest_files=[ "res://text/zh/font_help_dialog.zh.translation" ]
+dest_files=[ "res://text/zh/font_help_dialog.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/font_info.csv.import
+++ b/text/zh/font_info.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/font_info.zh.translation" ]
+files=[ "res://text/zh/font_info.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/font_info.csv"
-dest_files=[ "res://text/zh/font_info.zh.translation" ]
+dest_files=[ "res://text/zh/font_info.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/font_manager.csv.import
+++ b/text/zh/font_manager.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/font_manager.zh.translation" ]
+files=[ "res://text/zh/font_manager.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/font_manager.csv"
-dest_files=[ "res://text/zh/font_manager.zh.translation" ]
+dest_files=[ "res://text/zh/font_manager.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/fonts_tab.csv.import
+++ b/text/zh/fonts_tab.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/fonts_tab.zh.translation" ]
+files=[ "res://text/zh/fonts_tab.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/fonts_tab.csv"
-dest_files=[ "res://text/zh/fonts_tab.zh.translation" ]
+dest_files=[ "res://text/zh/fonts_tab.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/game_tab.csv.import
+++ b/text/zh/game_tab.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/game_tab.zh.translation" ]
+files=[ "res://text/zh/game_tab.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/game_tab.csv"
-dest_files=[ "res://text/zh/game_tab.zh.translation" ]
+dest_files=[ "res://text/zh/game_tab.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/general.csv.import
+++ b/text/zh/general.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/general.zh.translation" ]
+files=[ "res://text/zh/general.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/general.csv"
-dest_files=[ "res://text/zh/general.zh.translation" ]
+dest_files=[ "res://text/zh/general.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/helpers.csv.import
+++ b/text/zh/helpers.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/helpers.zh.translation" ]
+files=[ "res://text/zh/helpers.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/helpers.csv"
-dest_files=[ "res://text/zh/helpers.zh.translation" ]
+dest_files=[ "res://text/zh/helpers.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/install_probe.csv.import
+++ b/text/zh/install_probe.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/install_probe.zh.translation" ]
+files=[ "res://text/zh/install_probe.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/install_probe.csv"
-dest_files=[ "res://text/zh/install_probe.zh.translation" ]
+dest_files=[ "res://text/zh/install_probe.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/mod_manager.csv.import
+++ b/text/zh/mod_manager.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/mod_manager.zh.translation" ]
+files=[ "res://text/zh/mod_manager.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/mod_manager.csv"
-dest_files=[ "res://text/zh/mod_manager.zh.translation" ]
+dest_files=[ "res://text/zh/mod_manager.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/mod_reinstall_dialog.csv.import
+++ b/text/zh/mod_reinstall_dialog.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/mod_reinstall_dialog.zh.translation" ]
+files=[ "res://text/zh/mod_reinstall_dialog.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/mod_reinstall_dialog.csv"
-dest_files=[ "res://text/zh/mod_reinstall_dialog.zh.translation" ]
+dest_files=[ "res://text/zh/mod_reinstall_dialog.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/mods_tab.csv.import
+++ b/text/zh/mods_tab.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/mods_tab.zh.translation" ]
+files=[ "res://text/zh/mods_tab.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/mods_tab.csv"
-dest_files=[ "res://text/zh/mods_tab.zh.translation" ]
+dest_files=[ "res://text/zh/mods_tab.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/release_installer.csv.import
+++ b/text/zh/release_installer.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/release_installer.zh.translation" ]
+files=[ "res://text/zh/release_installer.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/release_installer.csv"
-dest_files=[ "res://text/zh/release_installer.zh.translation" ]
+dest_files=[ "res://text/zh/release_installer.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/release_manager.csv.import
+++ b/text/zh/release_manager.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/release_manager.zh.translation" ]
+files=[ "res://text/zh/release_manager.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/release_manager.csv"
-dest_files=[ "res://text/zh/release_manager.zh.translation" ]
+dest_files=[ "res://text/zh/release_manager.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/settings_manager.csv.import
+++ b/text/zh/settings_manager.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/settings_manager.zh.translation" ]
+files=[ "res://text/zh/settings_manager.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/settings_manager.csv"
-dest_files=[ "res://text/zh/settings_manager.zh.translation" ]
+dest_files=[ "res://text/zh/settings_manager.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/settings_tab.csv.import
+++ b/text/zh/settings_tab.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/settings_tab.zh.translation" ]
+files=[ "res://text/zh/settings_tab.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/settings_tab.csv"
-dest_files=[ "res://text/zh/settings_tab.zh.translation" ]
+dest_files=[ "res://text/zh/settings_tab.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/soundpack_manager.csv.import
+++ b/text/zh/soundpack_manager.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/soundpack_manager.zh.translation" ]
+files=[ "res://text/zh/soundpack_manager.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/soundpack_manager.csv"
-dest_files=[ "res://text/zh/soundpack_manager.zh.translation" ]
+dest_files=[ "res://text/zh/soundpack_manager.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/soundpacks_tab.csv.import
+++ b/text/zh/soundpacks_tab.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/soundpacks_tab.zh.translation" ]
+files=[ "res://text/zh/soundpacks_tab.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/soundpacks_tab.csv"
-dest_files=[ "res://text/zh/soundpacks_tab.zh.translation" ]
+dest_files=[ "res://text/zh/soundpacks_tab.zh_Hans_CN.translation" ]
 
 [params]
 

--- a/text/zh/tips.csv.import
+++ b/text/zh/tips.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://text/zh/tips.zh.translation" ]
+files=[ "res://text/zh/tips.zh_Hans_CN.translation" ]
 
 source_file="res://text/zh/tips.csv"
-dest_files=[ "res://text/zh/tips.zh.translation" ]
+dest_files=[ "res://text/zh/tips.zh_Hans_CN.translation" ]
 
 [params]
 


### PR DESCRIPTION
**Description:**

This adds full launcher integration for [Cataclysm: The Last Generation](https://github.com/Cataclysm-TLG/Cataclysm-TLG/tree/master), following the same patterns used for TISH and other forks.

**Key Changes:**

- Added TLG game option to UI dropdown and settings
- Implemented release fetching from TLG's GitHub repos
- Created isolated install paths to prevent conflicts
- Tested on Ubuntu 22.04 LTS with TLG build from March 2025

**Impact:**

- Lets players manage TLG installations alongside DDA/BN
- Requires no changes to existing workflows

**Verification:**

-  Confirmed working install/launch on fresh systems
-  Tested save file separation from DDA
-  Verified update checks work for TLG experimental builds

**Notes:**

- Release URL patterns match TLG's standard asset names
- Settings use tlg prefix to mirror existing conventions