### PR TITLE
Add Custom .PCK Theme Loading

### DIFF
--- a/scripts/SettingsUI.gd
+++ b/scripts/SettingsUI.gd
@@ -31,6 +31,8 @@ func _ready() -> void:
 	if lang_idx >= 0:
 		$LauncherLanguage/obtnLanguage.selected = lang_idx
 	
+	# Loads themes & assets from user dir, then adds to themes array.
+	FS.load_pck_themes_from_user_dir(_themes, $LauncherTheme/obtnTheme)
 	var theme_idx := _themes.find(Settings.read("launcher_theme"))
 	if theme_idx >= 0:
 		$LauncherTheme/obtnTheme.selected = theme_idx


### PR DESCRIPTION
### Adds support for loading custom themes through godot .PCK files.
With this change the user can change the color, icons, and logos of all parts of the Catapult client using custom themes.

NOTE: .PCK files could potentially contain executable code and as such should only be used when received from a trusted party.
![image](https://github.com/user-attachments/assets/3655a490-cbcc-41eb-8a5a-5742d050175e)
![image](https://github.com/user-attachments/assets/43ea7fa2-c9e2-4e5c-b61f-6ece198d880a)


### To create a theme:
Clone the repository locally and open with Godot.
Create a folder in res://themes called "custom"
Create a folder in res://themes/custom called "my_theme"
Duplicate an existing theme and icon into this folder, and rename them "my_theme" and "my_theme_logo"
![image](https://github.com/user-attachments/assets/87472a80-5339-4bfa-99f8-85bf1a056ff5)
Edit the theme as you see fit, and make sure to put any external assets included in the folder

To export, go to resources and change export mode to "Export selected resources (and dependencies)"
Select the custom folder and all of the assets used by your theme
And finally export the file as a .pck.
![image](https://github.com/user-attachments/assets/78976e99-b79d-4c2c-bd03-8c3373eab3be)
Put this .pck file in your Catapult userdata themes folder and you're done.
![image](https://github.com/user-attachments/assets/16c0b921-f53b-485e-83c1-2d303646f28b)
