### PR TITLE
Disable "keep screen on" in project settings

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -45,6 +45,7 @@ window/size/borderless=true
 window/size/transparent=true
 window/size/window_width_override=1
 window/size/window_height_override=1
+window/energy_saving/keep_screen_on=false
 window/per_pixel_transparency/allowed=true
 
 [gdnative]


### PR DESCRIPTION
This is not a game. It does not need to force my computer to keep its screen on when I leave it running by accident.

I just flipped the godot switch that does that over to "off"