### PR TITLE
chore(bn): add support for Cataclysm:Bright Nights version 0.10.0

### DIFF
--- a/scripts/ReleaseManager.gd
+++ b/scripts/ReleaseManager.gd
@@ -176,6 +176,11 @@ const _DDA_STABLE_WIN = [
 
 const _BN_STABLE_LINUX = [
 	{
+		"name": "0.10.0",
+		"url": "https://github.com/cataclysmbn/Cataclysm-BN/releases/download/v0.10.0/cbn-linux-tiles-x64-v0.10.0.tar.gz",
+		"filename": "cbn-linux-tiles-x64-v0.10.0.tar.gz"
+	},
+	{
 		"name": "0.9.1",
 		"url": "https://github.com/cataclysmbn/Cataclysm-BN/releases/download/v0.9.1/cbn-linux-tiles-x64-v0.9.1.tar.gz",
 		"filename": "cbn-linux-tiles-x64-v0.9.1.tar.gz"
@@ -243,6 +248,11 @@ const _BN_STABLE_LINUX = [
 ]
 
 const _BN_STABLE_WIN = [
+	{
+		"name": "0.10.0",
+		"url": "https://github.com/cataclysmbn/Cataclysm-BN/releases/download/v0.10.0/cbn-windows-tiles-x64-msvc-v0.10.0.zip",
+		"filename": "cbn-windows-tiles-x64-msvc-v0.10.0.zip"
+	},
 	{
 		"name": "0.9.1",
 		"url": "https://github.com/cataclysmbn/Cataclysm-BN/releases/download/v0.9.1/cbn-windows-tiles-x64-msvc-v0.9.1.zip",


### PR DESCRIPTION
Cataclysm:Bright Nights has release new stable - https://github.com/cataclysmbn/Cataclysm-BN/releases/tag/v0.10.0

this adds support for it