### PR TITLE
fix: Add proxy options to Settings UI

### DIFF
--- a/scripts/SettingsUI.gd
+++ b/scripts/SettingsUI.gd
@@ -47,6 +47,8 @@ func _ready() -> void:
 	%NumReleasesField.value = Settings.read("num_releases_to_request") as int
 	%NumPrsField.value = Settings.read("num_prs_to_request") as int
 	
+	for option in _proxy_options:
+		%ProxyOptionList.add_item(option)
 	var proxy_option_idx := _proxy_options.find(Settings.read("proxy_option"))
 	if proxy_option_idx >= 0:
 		%ProxyOptionList.selected = proxy_option_idx


### PR DESCRIPTION
This pull request makes a small improvement to the `SettingsUI` by ensuring that the proxy options are dynamically added to the proxy option dropdown list when the UI is initialized.

- UI Enhancement:
  * In `scripts/SettingsUI.gd`, the `_ready()` function now adds all available proxy options from `_proxy_options` to the `ProxyOptionList` UI element, ensuring the dropdown is populated correctly.

---

Generated By AI