### PR TITLE
Use the official Russian flag for the Russian locale

### DIFF
--- a/icons/lang/tex_lang_ru.tres
+++ b/icons/lang/tex_lang_ru.tres
@@ -9,7 +9,8 @@ _source = "<svg width=\"30\" height=\"20\" viewBox=\"0 0 238.125 158.75\" xmlns=
   </clipPath>
   <g clip-path=\"url(#roundedCorners)\">
     <path fill=\"#fff\" d=\"M0 0h238.125v158.75H0z\" />
-    <path fill=\"#088ce8\" d=\"M0 50.271h238.125v58.208H0z\" />
+    <path fill=\"#0039A6\" d=\"M0 52.9167h238.125v52.9166H0z\" />
+    <path fill=\"#D52B1E\" d=\"M0 105.8333h238.125v52.9167H0z\" />
   </g>
 </svg>"
 script = ExtResource("1_krqhf")


### PR DESCRIPTION
## Summary

Replace the Russian locale flag with the official flag of Russia.

The change is limited to `icons/lang/tex_lang_ru.tres` and preserves the existing icon dimensions and rounded-corner styling.

## Validation

- Successfully built using the repository's GitHub Actions workflow with Godot 4.5.1.
- Verified the Windows build and confirmed that the flag renders correctly in the language selector.

Related to #135.